### PR TITLE
SolrQuerySet for object-oriented Solr querying and filtering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,8 @@ To install before an official pypi release::
 
 To use with Django:
 
-    * Add `parasol` to **INSTALLED_APPS**
-    * Configure **SOLR_CONNECTIONS** in your django settings::
+* Add `parasol` to **INSTALLED_APPS**
+* Configure **SOLR_CONNECTIONS** in your django settings::
 
     SOLR_CONNECTIONS = {
         'default': {

--- a/parasol/indexing.py
+++ b/parasol/indexing.py
@@ -20,7 +20,7 @@ import logging
 try:
     from django.db.models.query import QuerySet
 
-    from parasol.solr.django import SolrClient
+    from parasol.django import SolrClient
 except ImportError:
     QuerySet = SolrClient = None
 

--- a/parasol/management/commands/index.py
+++ b/parasol/management/commands/index.py
@@ -39,7 +39,7 @@ from django.template.defaultfilters import pluralize
 import requests
 import progressbar
 
-from parasol.solr.django import SolrClient
+from parasol.django import SolrClient
 from parasol.indexing import Indexable
 
 

--- a/parasol/management/commands/solr_schema.py
+++ b/parasol/management/commands/solr_schema.py
@@ -13,7 +13,7 @@ Example usage::
 from django.core.management.base import BaseCommand, CommandError
 import requests
 
-from parasol.solr.django import SolrClient
+from parasol.django import SolrClient
 from parasol.schema import SolrSchema
 
 

--- a/parasol/query.py
+++ b/parasol/query.py
@@ -1,0 +1,224 @@
+from typing import Any, Optional
+
+from parasol.solr.django import SolrClient
+
+class SolrQuerySet:
+    """A Solr queryset object that allows for object oriented
+    searching and filtering of Solr results. Allows search results
+    to be paginated by django paginator."""
+
+    _result_cache = None
+    start = 0
+    stop = None
+    sort_options = []
+    search_qs = []
+    filter_qs = []
+
+    #: by default, combine search queries with AND
+    default_search_operator = 'AND'
+
+    def __init__(self, solr: Optional[SolrClient] = None):
+        self.solr = solr or SolrClient()
+        # convert search operator into form needed for combining queries
+        self._search_op = ' %s ' % self.default_search_operator
+
+    @property
+    def result(self):
+        if self._result_cache is None:
+            self.get_results()
+        return self._result_cache
+
+    def get_results(self, **kwargs):
+        """
+        Query Solr and get the results for the current query and filter
+        options. Populates result cache and returns the documents portion
+        of the reponse.
+
+        :return: docs as a list of dictionaries.
+        """
+        query_opts = self.query_opts()
+        query_opts.update(**kwargs)
+        # TODO: what do we do about the fact that Solr defaults
+        # to 10 rows?
+
+        # NOTE: django templates choke on AttrDict because it is
+        # callable; using dictionary response instead
+        self._result_cache = self.solr.query(wrap=False, **query_opts)
+        return self._result_cache['docs']
+
+    def query_opts(self):
+        """Construct query options based on current queryset configuration.
+        Includes filter queries, start and rows, sort, and search query.
+        """
+        query_opts = {
+            'start': self.start,
+        }
+        if self.filter_qs:
+            query_opts['fq'] = self.filter_qs
+        if self.stop:
+            query_opts['rows'] = self.stop - self.start
+        if self.sort_options:
+            query_opts['sort'] = ','.join(self.sort_options)
+
+        # main query; if no query is defined, find everything
+        if self.search_qs:
+            query_opts['q'] = self._search_op.join(self.search_qs)
+        else:
+            query_opts['q'] = '*:*'
+
+        return query_opts
+
+    def count(self):
+        """Total number of results for the current query"""
+
+        # if result cache is already populated, use it
+        if self._result_cache is not None:
+            return self._result_cache['numFound']
+
+        # otherwise, query with current options but request zero rows
+        # and do not populate the result cache
+        query_opts = self.query_opts()
+        query_opts['rows'] = 0
+        return self.solr.query(**query_opts, wrap=False)['numFound']
+
+    @staticmethod
+    def _lookup_to_filter(key, value):
+        """Convert keyword argument key=value pair into a Solr filter.
+        Currently only supports simple case of field:value."""
+
+        # NOTE: as needed, we can start implementing django-style filters
+        # such as __in=[a, b, c] or __range=(start, end)
+        return '%s:%s' % (key, value)
+
+    def filter(self, *args, **kwargs):
+        """
+        Return a new SolrQuerySet with Solr filter queries added.
+        """
+        qs_copy = self._clone()
+
+        # any args are treated as filter queries without modification
+        qs_copy.filter_qs.extend(args)
+
+        for key, value in kwargs.items():
+            qs_copy.filter_qs.append(self._lookup_to_filter(key, value))
+
+        return qs_copy
+
+    def search(self, *args, **kwargs):
+        """
+        Return a new SolrQuerySet with search queries added. All
+        queries will combined with the default search operator when
+        constructing the `q` parameter sent to Solr..
+        """
+        qs_copy = self._clone()
+        # any args are treated as search queries without modification
+        qs_copy.search_qs.extend(args)
+
+        for key, value in kwargs.items():
+            qs_copy.search_qs.append(self._lookup_to_filter(key, value))
+
+        return qs_copy
+
+    def order_by(self, *args):
+        """apply sort options to the queryset"""
+        qs_copy = self._clone()
+        for sort_option in args:
+            if sort_option.startswith('-'):
+                sort_order = 'desc'
+                sort_option = sort_option.lstrip('-')
+            else:
+                sort_order = 'asc'
+            qs_copy.sort_options.append('%s %s' % (sort_option, sort_order))
+
+        return qs_copy
+
+    def query(self, **kwargs):
+        """Return a new SolrQuerySet with the results populated from Solr.
+        Any options passed in via keyword arguments take precedence
+        over query options on the queryset.
+        """
+        qs_copy = self._clone()
+        qs_copy.get_results(**kwargs)
+        return qs_copy
+
+    def all(self):
+        """Return a new queryset that is a copy of the current one."""
+        return self._clone()
+
+    def none(self):
+        """Return an empty result list."""
+        qs_copy = self._clone()
+        # replace any search queries with this to find not anything
+        qs_copy.search_qs = ['NOT *:*']
+        return qs_copy
+
+    def _clone(self):
+        """
+        Return a copy of the current QuerySet for modification via
+        filters.
+        """
+        # create a new instance with same solr and query opts
+        # use current class to support extending
+        qs_copy = self.__class__(solr=self.solr)
+        # set attributes that can be copied directly
+        qs_copy.start = self.start
+        qs_copy.stop = self.stop
+
+        # set copies of list attributes
+        qs_copy.search_qs = list(self.search_qs)
+        qs_copy.filter_qs = list(self.filter_qs)
+        qs_copy.sort_options = list(self.sort_options)
+
+        return qs_copy
+
+    def set_limits(self, start, stop):
+        """Return a subsection of the results, to support slicing."""
+        if start is None:
+            start = 0
+        self.start = start
+        self.stop = stop
+
+    iter_chunk_size = 1000
+
+    def __iter__(self):
+        """Iterate over result documents for this query."""
+        return iter(self.get_results())
+
+    def __bool__(self):
+        """results are not empty"""
+        return bool(self.get_results())
+
+    def __getitem__(self, k):
+        """Return a single result or a slice of results"""
+        # based on django queryset logic
+        if not isinstance(k, (int, slice)):
+            raise TypeError
+        assert ((not isinstance(k, slice) and (k >= 0)) or
+                (isinstance(k, slice) and (k.start is None or k.start >= 0) and
+                 (k.stop is None or k.stop >= 0))), \
+            "Negative indexing is not supported."
+
+        if self._result_cache is not None:
+            return self._result_cache['docs'][k]
+
+        if isinstance(k, slice):
+            if k.start is not None:
+                start = int(k.start)
+            else:
+                start = None
+            if k.stop is not None:
+                stop = int(k.stop)
+            else:
+                stop = None
+
+            qs_copy = self._clone()
+            qs_copy.set_limits(start, stop)
+            return list(qs_copy)[::k.step] if k.step else qs_copy
+
+            # FIXME: django templates chokes on attrdict
+            # return [dict(result) for result in chunk]
+            # return
+
+        # single item
+        self.set_limits(k, k + 1)
+        return self.get_results()[0]

--- a/parasol/query.py
+++ b/parasol/query.py
@@ -28,12 +28,6 @@ class SolrQuerySet:
         # convert search operator into form needed for combining queries
         self._search_op = ' %s ' % self.default_search_operator
 
-    @property
-    def result(self):
-        if self._result_cache is None:
-            self.get_results()
-        return self._result_cache
-
     def get_results(self, **kwargs):
         """
         Query Solr and get the results for the current query and filter

--- a/parasol/query.py
+++ b/parasol/query.py
@@ -13,7 +13,7 @@ chained. For example::
 
 """
 
-from typing import Any, Optional
+from typing import Any, Optional, Dict, List
 
 try:
     from parasol.solr.django import SolrClient
@@ -42,7 +42,7 @@ class SolrQuerySet:
         # convert search operator into form needed for combining queries
         self._search_op = ' %s ' % self.default_search_operator
 
-    def get_results(self, **kwargs):
+    def get_results(self, **kwargs) -> List[dict]:
         """
         Query Solr and get the results for the current query and filter
         options. Populates result cache and returns the documents portion
@@ -66,7 +66,7 @@ class SolrQuerySet:
         self._result_cache = self.solr.query(wrap=False, **query_opts)
         return self._result_cache['response']['docs']
 
-    def query_opts(self):
+    def query_opts(self) -> Dict[str, str]:
         """Construct query options based on current queryset configuration.
         Includes filter queries, start and rows, sort, and search query.
         """
@@ -88,7 +88,7 @@ class SolrQuerySet:
 
         return query_opts
 
-    def count(self):
+    def count(self) -> int:
         """Total number of results for the current query"""
 
         # if result cache is already populated, use it
@@ -102,7 +102,7 @@ class SolrQuerySet:
         return self.solr.query(**query_opts, wrap=False)['response']['numFound']
 
     @staticmethod
-    def _lookup_to_filter(key, value):
+    def _lookup_to_filter(key, value) -> str:
         """Convert keyword argument key=value pair into a Solr filter.
         Currently only supports simple case of field:value."""
 

--- a/parasol/query.py
+++ b/parasol/query.py
@@ -6,27 +6,28 @@ slicing, counting, and boolean check to see if a search has results.
 Filter, search and sort methods return a new queryset, and can be
 chained. For example::
 
-    SolrQuerySet().filter(item_type='person') \
-                  .search(name='hem*') \
-                  .order_by('sort_name') \
+    SolrQuerySet(solrclient).filter(item_type='person') \
+                            .search(name='hem*') \
+                            .order_by('sort_name') \
 
 
+If you are working with Django you should use
+:class:`parasol.django.SolrQuerySet`,
+which will automatically initialize a new :class:`parasol.django.SolrClient`
+if one is not passed in.
 """
 
-from typing import Optional, Dict, List
+from typing import Dict, List
 
-try:
-    from parasol.solr.django import SolrClient
-except ImportError:
-    # FIXME: SolrQuerySet doesn't currently work with non-django
-    # solr client because it would need a way to get connection settings
-    from parasol.solr import SolrClient
+from parasol.solr import SolrClient
 
 
 class SolrQuerySet:
     """A Solr queryset object that allows for object oriented
     searching and filtering of Solr results. Allows search results
-    to be paginated by django paginator."""
+    to be pagination using slicing, count, and iteration.
+
+    """
 
     _result_cache = None
     start = 0
@@ -41,8 +42,9 @@ class SolrQuerySet:
     #: by default, combine search queries with AND
     default_search_operator = 'AND'
 
-    def __init__(self, solr: Optional[SolrClient] = None):
-        self.solr = solr or SolrClient()
+    def __init__(self, solr: SolrClient):
+        # requires solr client so that this version can be django-agnostic
+        self.solr = solr
         # convert search operator into form needed for combining queries
         self._search_op = ' %s ' % self.default_search_operator
 

--- a/parasol/query.py
+++ b/parasol/query.py
@@ -1,3 +1,18 @@
+"""
+Object-oriented approach to Solr searching and filtering modeled
+on :class:`django.models.queryset.QuerySet`.  Supports iteration,
+slicing, counting, and boolean check to see if a search has results.
+
+Filter, search and sort methods return a new queryset, and can be
+chained. For example::
+
+    SolrQuerySet().filter(item_type='person') \
+                  .search(name='hem*') \
+                  .order_by('sort_name') \
+
+
+"""
+
 from typing import Any, Optional
 
 try:
@@ -34,7 +49,8 @@ class SolrQuerySet:
         options. Populates result cache and returns the documents portion
         of the reponse.
 
-        :return: docs as a list of dictionaries.
+        Returns:
+            Solr response documents as a list of dictionaries.
         """
         query_opts = self.query_opts()
         query_opts.update(**kwargs)
@@ -120,7 +136,8 @@ class SolrQuerySet:
         return qs_copy
 
     def order_by(self, *args):
-        """apply sort options to the queryset"""
+        """Apply sort options to the queryset by field name. If the field
+        name starts with -, sort is descending; otherwise ascending."""
         qs_copy = self._clone()
         for sort_option in args:
             if sort_option.startswith('-'):

--- a/parasol/query.py
+++ b/parasol/query.py
@@ -1,6 +1,12 @@
 from typing import Any, Optional
 
-from parasol.solr.django import SolrClient
+try:
+    from parasol.solr.django import SolrClient
+except ImportError:
+    # FIXME: SolrQuerySet doesn't currently work with non-django
+    # solr client because it would need a way to get connection settings
+    from parasol.solr import SolrClient
+
 
 class SolrQuerySet:
     """A Solr queryset object that allows for object oriented

--- a/parasol/solr/client.py
+++ b/parasol/solr/client.py
@@ -85,8 +85,8 @@ class SolrClient(ClientBase):
     commitWithin = 1000
 
     def __init__(self, solr_url: str, collection: str,
-                 commitWithin: Optional[int]=None,
-                 session: Optional[requests.Session]=None) -> None:
+                 commitWithin: Optional[int] = None,
+                 session: Optional[requests.Session] = None) -> None:
         # Go ahead and create a session if one is not passed in
         super().__init__(session=session)
 
@@ -118,7 +118,7 @@ class SolrClient(ClientBase):
             self.core_admin_handler,
             self.session)
 
-    def query(self, **kwargs: Any) -> Optional[QueryReponse]:
+    def query(self, wrap: bool = True, **kwargs: Any) -> Optional[QueryReponse]:
         """Perform a query with the specified kwargs.
 
         Args:
@@ -139,4 +139,4 @@ class SolrClient(ClientBase):
         )
         if response:
             # queries return the search response for now
-            return QueryReponse(response)
+            return QueryReponse(response) if wrap else response['response']

--- a/parasol/solr/client.py
+++ b/parasol/solr/client.py
@@ -139,4 +139,4 @@ class SolrClient(ClientBase):
         )
         if response:
             # queries return the search response for now
-            return QueryReponse(response) if wrap else response['response']
+            return QueryReponse(response) if wrap else response

--- a/parasol/solr/tests.py
+++ b/parasol/solr/tests.py
@@ -177,6 +177,19 @@ class TestClientBase:
         )
         assert response is None
 
+        # test wrap = false
+        mockresp = Mock()
+        mockresp.status_code = 200
+        mockresp.json.return_value = {
+            'responseHeader': {
+                'status': 0,
+                'QTime': 0
+            }
+        }
+        response = client_base.make_request('post', 'http://localhost/',
+                                            wrap=False)
+        assert not isinstance(response, AttrDict)
+
 
 class TestQueryResponse:
 
@@ -270,9 +283,11 @@ class TestSolrClient:
         # not paginated so should be starting at 0
         assert response.start == 0
         # should be the two expected documents
+        # FIXME: these lines have no effect
         {'A': 'bar', 'B': 20, 'id': 2}
         {'A': 'baz', 'B': 25, 'id': 3} in response.docs
         {'A': 'baz', 'B': 30, 'id': 4} in response.docs
+
         # test faceting in response
         response = test_client.query(
             q='*:*',
@@ -296,6 +311,11 @@ class TestSolrClient:
         # check that the gaps are generated as expected
         assert response.facet_counts.facet_ranges['B']['counts']['1'] == 1
         assert response.facet_counts.facet_ranges['B']['counts']['11'] == 1
+
+        # test wrap = False
+        response = test_client.query(q='*:*', wrap=False)
+        assert not isinstance(response, QueryReponse)
+
 
 class TestUpdate:
 

--- a/parasol/tests/test_query.py
+++ b/parasol/tests/test_query.py
@@ -49,13 +49,13 @@ class TestSolrQuerySet:
     def test_get_results(self, mocksolrclient):
         sqs = SolrQuerySet()
 
-        mockresponse = {'docs': [{'id': 1}]}
+        mockresponse = {'response': {'docs': [{'id': 1}]}}
         mocksolrclient.return_value.query.return_value = mockresponse
 
         # by default, should query solr with options from query_opts
         # and wrap = false
         query_opts = sqs.query_opts()
-        assert sqs.get_results() == mockresponse['docs']
+        assert sqs.get_results() == mockresponse['response']['docs']
         assert sqs._result_cache == mockresponse
         mocksolrclient.return_value.query \
                       .assert_called_with(**query_opts, wrap=False)
@@ -73,13 +73,13 @@ class TestSolrQuerySet:
 
         mocksolr = mocksolrclient.return_value
         # simulate result cache already populated; should use
-        sqs._result_cache = {'numFound': 5009}
-        assert sqs.count() == sqs._result_cache['numFound']
+        sqs._result_cache = {'response': {'numFound': 5009}}
+        assert sqs.count() == sqs._result_cache['response']['numFound']
         mocksolr.query.assert_not_called()
 
         # if cache is not populated, should query for count
         sqs._result_cache = None
-        mocksolr.query.return_value = {'numFound': 343}
+        mocksolr.query.return_value = {'response': {'numFound': 343}}
         assert sqs.count() == 343
         count_query_opts = sqs.query_opts()
         count_query_opts['rows'] = 0
@@ -275,7 +275,7 @@ class TestSolrQuerySet:
         sqs = SolrQuerySet()
 
         # simulate result cache already populated
-        sqs._result_cache = {'docs': [1, 2, 3, 4, 5]}
+        sqs._result_cache = {'response': {'docs': [1, 2, 3, 4, 5]}}
         # single item
         assert sqs[0] == 1
         assert sqs[1] == 2

--- a/parasol/tests/test_query.py
+++ b/parasol/tests/test_query.py
@@ -1,0 +1,258 @@
+from unittest.mock import patch, Mock
+
+from parasol.solr import SolrClient
+from parasol.query import SolrQuerySet
+
+
+@patch('parasol.query.SolrClient')
+class TestSolrQuerySet:
+
+    def test_init(self, mocksolrclient):
+        # auto-initialize solr connection if not specified
+        sqs = SolrQuerySet()
+        mocksolrclient.assert_called_with()
+        assert sqs.solr == mocksolrclient.return_value
+
+        # use solr client if passed in
+        mocksolrclient.reset_mock()
+        mocksolr = Mock(spec=SolrClient)
+        sqs = SolrQuerySet(solr=mocksolr)
+        assert sqs.solr == mocksolr
+        mocksolrclient.assert_not_called()
+
+    def test_query_opts(self, mocksolrclient):
+        sqs = SolrQuerySet()
+
+        # default behavior: find all starting at 0
+        query_opts = sqs.query_opts()
+        assert query_opts['start'] == 0
+        assert query_opts['q'] == '*:*'
+        # don't include unset options
+        for opt in ['fq', 'rows', 'sort']:
+            assert opt not in query_opts
+
+        # customized query opts
+        sqs.start = 10
+        sqs.stop = 20
+        sqs.sort_options = ['title asc', 'date desc']
+        sqs.filter_qs = ['item_type:work']
+        sqs.search_qs = ['title:reading', 'author:johnson']
+        query_opts = sqs.query_opts()
+        assert query_opts['start'] == sqs.start
+        assert query_opts['rows'] == sqs.stop - sqs.start
+        assert query_opts['fq'] == sqs.filter_qs
+        assert query_opts['q'] == ' AND '.join(sqs.search_qs)
+        assert query_opts['sort'] == ','.join(sqs.sort_options)
+
+    def test_get_results(self, mocksolrclient):
+        sqs = SolrQuerySet()
+
+        mockresponse = {'docs': [{'id': 1}]}
+        mocksolrclient.return_value.query.return_value = mockresponse
+
+        # by default, should query solr with options from query_opts
+        # and wrap = false
+        query_opts = sqs.query_opts()
+        assert sqs.get_results() == mockresponse['docs']
+        assert sqs._result_cache == mockresponse
+        mocksolrclient.return_value.query \
+                      .assert_called_with(**query_opts, wrap=False)
+
+        # parameters passed in take precedence
+        local_opts = {'q': 'name:hemingway', 'sort': 'name asc'}
+        sqs.get_results(**local_opts)
+        # update copy of query opts with locally passed in params
+        query_opts.update(local_opts)
+        mocksolrclient.return_value.query \
+                      .assert_called_with(**query_opts, wrap=False)
+
+    def test_count(self, mocksolrclient):
+        sqs = SolrQuerySet()
+
+        mocksolr = mocksolrclient.return_value
+        # simulate result cache already populated; should use
+        sqs._result_cache = {'numFound': 5009}
+        assert sqs.count() == sqs._result_cache['numFound']
+        mocksolr.query.assert_not_called()
+
+        # if cache is not populated, should query for count
+        sqs._result_cache = None
+        mocksolr.query.return_value = {'numFound': 343}
+        assert sqs.count() == 343
+        count_query_opts = sqs.query_opts()
+        count_query_opts['rows'] = 0
+        mocksolr.query.assert_called_with(**count_query_opts, wrap=False)
+        # cache should not be populated
+        assert not sqs._result_cache
+
+    def test_filter(self, mocksolrclient):
+        sqs = SolrQuerySet()
+
+        # arg options added to filter list as is
+        new_filters = ['item_type:work', 'date:[1550 TO 1900]']
+        filtered_qs = sqs.filter(*new_filters)
+        # returned queryset has the filters
+        assert filtered_qs.filter_qs == new_filters
+        # original queryset is unchanged
+        assert not sqs.filter_qs
+
+        # keyword arg options converted into filters
+        filtered_qs = sqs.filter(item_type='work', date=1500)
+        # returned queryset has the filters
+        assert 'item_type:work' in filtered_qs.filter_qs
+        assert 'date:1500' in filtered_qs.filter_qs
+        # original queryset is unchanged
+        assert not sqs.filter_qs
+
+        # chaining adds to the filters
+        filtered_qs = sqs.filter(item_type='work').filter(date=1500) \
+                         .filter('name:he*')
+        assert 'item_type:work' in filtered_qs.filter_qs
+        assert 'date:1500' in filtered_qs.filter_qs
+        assert 'name:he*' in filtered_qs.filter_qs
+
+    def test_search(self, mocksolrclient):
+        sqs = SolrQuerySet()
+
+        # arg options added to filter list as is
+        queries = ['item_type:work', 'date:[1550 TO *]']
+        search_sqs = sqs.search(*queries)
+        # returned queryset has the filters
+        assert search_sqs.search_qs == queries
+        # original queryset is unchanged
+        assert not sqs.search_qs
+
+        # keyword arg options are converted
+        search_sqs = sqs.search(item_type='work', date=1550)
+        assert 'item_type:work' in search_sqs.search_qs
+        assert 'date:1550' in search_sqs.search_qs
+        # original queryset is unchanged
+        assert not sqs.search_qs
+
+        # chaining is additive
+        search_sqs = sqs.search(item_type='work').search(date=1550)
+        assert 'item_type:work' in search_sqs.search_qs
+        assert 'date:1550' in search_sqs.search_qs
+        # original queryset is unchanged
+        assert not sqs.search_qs
+
+    def test_order_by(self, mocksolrclient):
+        sqs = SolrQuerySet()
+
+        # default is ascending
+        sorted_sqs = sqs.order_by('date')
+        assert sorted_sqs.sort_options == ['date asc']
+        # original queryset is unchanged
+        assert not sqs.sort_options
+
+        # - indicates descending
+        sorted_sqs = sqs.order_by('-date')
+        assert sorted_sqs.sort_options == ['date desc']
+        # original queryset is unchanged
+        assert not sqs.sort_options
+
+        # can handle multiple
+        sorted_sqs = sqs.order_by('title', 'date')
+        assert sorted_sqs.sort_options == ['title asc', 'date asc']
+        # original queryset is unchanged
+        assert not sqs.sort_options
+
+        # chaining works the same way
+        sorted_sqs = sqs.order_by('title').order_by('date')
+        assert sorted_sqs.sort_options == ['title asc', 'date asc']
+        # original queryset is unchanged
+        assert not sqs.sort_options
+
+    def test_all(self, mocksolrclient):
+        sqs = SolrQuerySet()
+        # all just calls clone and returns the queryset copy
+        with patch.object(sqs, '_clone') as mockclone:
+            all_sqs = sqs.all()
+            mockclone.assert_called_with()
+            assert all_sqs == mockclone.return_value
+
+    def test_none(self, mocksolrclient):
+        sqs = SolrQuerySet()
+        none_sqs = sqs.none()
+        # new queryset search replaced with something to return nothing
+        assert none_sqs.search_qs == ['NOT *:*']
+        # original queryset unchanged
+        assert sqs.search_qs == []
+
+        # none after search terms replaces the search
+        search_sqs = SolrQuerySet().search('item_type:work')
+        none_sqs = search_sqs.none()
+        assert search_sqs.search_qs == ['item_type:work']
+        assert none_sqs.search_qs == ['NOT *:*']
+
+    def test__clone(self, mocksolrclient):
+        sqs = SolrQuerySet()
+        # clone default with no filters
+        cloned_sqs = sqs._clone()
+        assert cloned_sqs.start == 0
+        assert cloned_sqs.stop is None
+        assert cloned_sqs.search_qs == []
+        assert cloned_sqs.filter_qs == []
+        assert cloned_sqs.sort_options == []
+
+        # set everything
+        custom_sqs = sqs.filter(item_type='person').search(name='he*') \
+                        .order_by('birth_year')
+        custom_sqs.set_limits(10, 100)
+        custom_clone = custom_sqs._clone()
+        assert custom_clone.start == 10
+        assert custom_clone.stop == 100
+        # list fields should be equal but not be the same object
+        assert custom_clone.search_qs == custom_sqs.search_qs
+        assert not custom_clone.search_qs is custom_sqs.search_qs
+        assert custom_clone.filter_qs == custom_sqs.filter_qs
+        assert not custom_clone.filter_qs is custom_sqs.filter_qs
+        assert custom_clone.sort_options == custom_sqs.sort_options
+        assert not custom_clone.sort_options is custom_sqs.sort_options
+
+        # subclass clone should return subclass
+
+        class CustomSolrQuerySet(SolrQuerySet):
+            pass
+
+        custom_clone = CustomSolrQuerySet()._clone()
+        assert isinstance(custom_clone, CustomSolrQuerySet)
+
+        # sanity-check chaining
+        sqs = SolrQuerySet()
+        filtered_sqs = sqs.filter(item_type='person')
+        # filter should be set
+        assert 'item_type:person' in filtered_sqs.filter_qs
+        sorted_sqs = filtered_sqs.order_by('birth_year')
+        # sort and filter should be set
+        assert 'item_type:person' in sorted_sqs.filter_qs
+        assert 'birth_year asc' in sorted_sqs.sort_options
+        search_sqs = sorted_sqs.search(name='hem*')
+        # search , sort, and filter should be set
+        assert 'item_type:person' in search_sqs.filter_qs
+        assert 'birth_year asc' in search_sqs.sort_options
+        assert 'name:hem*' in search_sqs.search_qs
+
+    def test__lookup_to_filter(self, mocksolrclient):
+        assert SolrQuerySet._lookup_to_filter('item_type', 'work') == \
+            'item_type:work'
+
+    def test_iter(self, mocksolrclient):
+        sqs = SolrQuerySet()
+        with patch.object(sqs, 'get_results') as mock_get_results:
+            mock_get_results.return_value = [{'id': 1}, {'id': 2}]
+            results_iterator = sqs.__iter__()
+            # not sure how best to test iterator...
+            assert list(results_iterator) == mock_get_results.return_value
+            mock_get_results.assert_called_with()
+
+    def test_bool(self, mocksolrclient):
+        sqs = SolrQuerySet()
+        with patch.object(sqs, 'get_results') as mock_get_results:
+            # with results
+            mock_get_results.return_value = [{'id': 1}, {'id': 2}]
+            assert sqs
+
+            # with no results
+            mock_get_results.return_value = []
+            assert not sqs

--- a/parasol/tests/test_query.py
+++ b/parasol/tests/test_query.py
@@ -291,6 +291,17 @@ class TestSolrQuerySet:
         assert isinstance(sliced_qs, SolrQuerySet)
         assert sliced_qs.start == 10
         assert sliced_qs.stop == 20
+        # - slice with implicit start
+        sliced_qs = sqs[:5]
+        assert isinstance(sliced_qs, SolrQuerySet)
+        assert sliced_qs.start == 0
+        assert sliced_qs.stop == 5
+        # - slice with implicit end
+        sliced_qs = sqs[3:]
+        assert isinstance(sliced_qs, SolrQuerySet)
+        assert sliced_qs.start == 3
+        assert sliced_qs.stop is None
+
         # - slice with step
         sliced_qs = sqs[0:10:2]
         assert not isinstance(sliced_qs, SolrQuerySet)

--- a/sphinx-docs/codedocs.rst
+++ b/sphinx-docs/codedocs.rst
@@ -57,6 +57,11 @@ QuerySet
 .. automodule:: parasol.query
    :members:
 
+Django
+------
+
+.. automodule:: parasol.django
+    :members:
 
 
 Manage Commands

--- a/sphinx-docs/codedocs.rst
+++ b/sphinx-docs/codedocs.rst
@@ -51,6 +51,13 @@ Indexing
 .. automodule:: parasol.indexing
    :members:
 
+QuerySet
+--------
+
+.. automodule:: parasol.query
+   :members:
+
+
 
 Manage Commands
 ---------------

--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -16,6 +16,13 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 
+import django
+
+sys.path.insert(0, os.path.abspath('..'))
+
+os.environ['DJANGO_SETTINGS_MODULE'] = 'testsettings'
+django.setup()
+
 from parasol import __version__
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
Defines a `SolrQuerySet` object based in part on the paginated solr response model from PPA and partly on queryset objects from Django and django-haystack.

Includes count and slicing, indexing, and iteration methods to work with django paginator; chaining methods to apply filters, search queries, and sort options. It includes a generic `query` method that will allow any solr search terms through, which should provide access to any features that aren't yet available as methods on the queryset object.