### PR TITLE
Feature/support configset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,8 @@ To use with Django:
         'default': {
         'URL': 'http://localhost:8983/solr/',
         'COLLECTION': 'name',
+        # any configSet in SOLR_ROOT/server/solr/configsets
+        'CONFIGSET': 'basic_configs'
         }
     }
 

--- a/ci/testsettings.py
+++ b/ci/testsettings.py
@@ -22,9 +22,10 @@ INSTALLED_APPS = (
 # from top level project folder
 SOLR_CONNECTIONS = {
     'test': {
-        'solr_url': 'http://localhost:8983/solr/',
-        'collection': 'parasol_test',
+        'URL': 'http://localhost:8983/solr/',
+        'COLLECTION': 'parasol_test',
         # aggressive commitWithin for test only
-        'commitWithin': 750
+        'COMMITWITHIN': 750,
+        'CONFIGSET': 'basic_configs'
     }
 }

--- a/parasol/django.py
+++ b/parasol/django.py
@@ -61,6 +61,11 @@ if django:
                 raise ImproperlyConfigured('No URL in default SOLR_CONNECTIONS configuration')
 
             collection = default_solr.get('COLLECTION', '')
+
+            # if a CONFIGSET name is supplied, set it on SolrClient for use
+            # later, otherwise, default to 'basic_configs'
+            self.configSet = default_solr.get('CONFIGSET', 'basic_configs')
+
             logger.info('Connecting to default Solr %s%s', url, collection)
             super().__init__(url, collection, *args, **kwargs)
 

--- a/parasol/django.py
+++ b/parasol/django.py
@@ -62,10 +62,6 @@ if django:
 
             collection = default_solr.get('COLLECTION', '')
 
-            # if a CONFIGSET name is supplied, set it on SolrClient for use
-            # later, otherwise, default to 'basic_configs'
-            self.configSet = default_solr.get('CONFIGSET', 'basic_configs')
-
             logger.info('Connecting to default Solr %s%s', url, collection)
             super().__init__(url, collection, *args, **kwargs)
 

--- a/parasol/management/commands/solr_schema.py
+++ b/parasol/management/commands/solr_schema.py
@@ -10,6 +10,7 @@ Example usage::
 
 """
 
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 import requests
 
@@ -52,8 +53,11 @@ class Command(BaseCommand):
                 create = input('Solr core %s does not exist. Create it? (y/n)' %
                                solr.collection).lower() == 'y'
             if create:
-                solr.core_admin.create(solr.collection,
-                                       configSet=solr.configSet)
+                # The error handling for ensuring there's a configuration
+                # has already happened, so just get default
+                default_solr = settings.SOLR_CONNECTIONS['default']
+                configSet = default_solr.get('CONFIGSET', 'basic_configs')
+                solr.core_admin.create(solr.collection, configSet=configSet)
             else:
                 # if core was not created, bail out
                 return

--- a/parasol/management/commands/solr_schema.py
+++ b/parasol/management/commands/solr_schema.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
                                solr.collection).lower() == 'y'
             if create:
                 solr.core_admin.create(solr.collection,
-                                       configSet='basic_configs')
+                                       configSet=solr.configSet)
             else:
                 # if core was not created, bail out
                 return

--- a/parasol/solr/base.py
+++ b/parasol/solr/base.py
@@ -21,6 +21,11 @@ class CoreExists(SolrClientException):
     pass
 
 
+class ImproperConfiguration(SolrClientException):
+    """Raised when a required setting is not present or is an invalid value."""
+    pass
+
+
 class ClientBase:
     """Base object with common communication methods for talking to Solr API.
 

--- a/parasol/solr/client.py
+++ b/parasol/solr/client.py
@@ -83,8 +83,7 @@ class SolrClient(ClientBase):
     collection = ''
     #: commitWithin time in ms
     commitWithin = 1000
-    #: Default configSet for any automated core creation
-    configSet = 'basic_configs'
+
 
     def __init__(self, solr_url: str, collection: str,
                  commitWithin: Optional[int] = None,

--- a/parasol/solr/client.py
+++ b/parasol/solr/client.py
@@ -81,8 +81,10 @@ class SolrClient(ClientBase):
     update_handler = 'update'
     #: core or collection name
     collection = ''
-    # commitWithin time in ms
+    #: commitWithin time in ms
     commitWithin = 1000
+    #: Default configSet for any automated core creation
+    configSet = 'basic_configs'
 
     def __init__(self, solr_url: str, collection: str,
                  commitWithin: Optional[int] = None,

--- a/parasol/solr/test_solr.py
+++ b/parasol/solr/test_solr.py
@@ -8,7 +8,7 @@ from unittest.mock import patch, Mock
 from attrdict import AttrDict
 import requests
 
-from parasol.solr.base import CoreExists, ClientBase
+from parasol.solr.base import CoreExists, ClientBase, ImproperConfiguration
 from parasol.solr.client import SolrClient, QueryReponse
 from parasol.solr.schema import Schema
 from parasol.solr.update import Update
@@ -61,7 +61,13 @@ def test_client(request):
     solr_url = TEST_SOLR_CONNECTION.get('URL', None)
     collection = TEST_SOLR_CONNECTION.get('COLLECTION', None)
     commitWithin  = TEST_SOLR_CONNECTION.get('COMMITWITHIN', None)
-    configSet = TEST_SOLR_CONNECTION.get('CONFIGSET', None)
+    configSet = TEST_SOLR_CONNECTION.get('CONFIGSET', 'basic_configs')
+
+    if not solr_url or not collection:
+        raise ImproperConfiguration(
+            "Test client requires URL and COLLECTION in SOLR_CONNECTIONS."
+        )
+
 
     client = SolrClient(solr_url, collection, commitWithin=commitWithin)
 
@@ -97,6 +103,13 @@ def core_test_client(request):
     """
     solr_url = TEST_SOLR_CONNECTION.get('URL', None)
     commitWithin  = TEST_SOLR_CONNECTION.get('COMMITWITHIN', None)
+
+    if not solr_url:
+        raise ImproperConfiguration(
+            "Core admin test client requires URL setting in SOLR_CONNECTIONS."
+        )
+
+
     core_name = str(uuid.uuid4())
 
     client = SolrClient(solr_url, core_name, commitWithin=commitWithin)

--- a/parasol/solr/test_solr.py
+++ b/parasol/solr/test_solr.py
@@ -61,7 +61,6 @@ def test_client(request):
     solr_url = TEST_SOLR_CONNECTION.get('URL', None)
     collection = TEST_SOLR_CONNECTION.get('COLLECTION', None)
     commitWithin  = TEST_SOLR_CONNECTION.get('COMMITWITHIN', None)
-    configSet = TEST_SOLR_CONNECTION.get('CONFIGSET', 'basic_configs')
 
     if not solr_url or not collection:
         raise ImproperConfiguration(
@@ -74,7 +73,7 @@ def test_client(request):
     response = client.core_admin.status(core=collection)
     if response.status.parasol_test:
         raise CoreExists('Test core "parasol_test" exists, aborting!')
-    client.core_admin.create(collection, configSet=configSet)
+    client.core_admin.create(collection, configSet='basic_configs')
 
     def clean_up():
         for field in TEST_FIELDS:
@@ -619,8 +618,7 @@ class TestCoreAdmin:
 
     def test_create_unload(self, core_test_client):
         test_client, core = core_test_client
-        configSet = TEST_SOLR_CONNECTION.get('CONFIGSET', 'basic_configs')
-        test_client.core_admin.create(core, configSet=configSet)
+        test_client.core_admin.create(core, configSet='basic_configs')
         resp = test_client.core_admin.status(core=core)
         assert not resp.initFailures
         # core has a start time

--- a/parasol/solr/test_solr.py
+++ b/parasol/solr/test_solr.py
@@ -606,7 +606,8 @@ class TestCoreAdmin:
 
     def test_create_unload(self, core_test_client):
         test_client, core = core_test_client
-        test_client.core_admin.create(core, configSet='basic_configs')
+        configSet = TEST_SOLR_CONNECTION.get('CONFIGSET', 'basic_configs')
+        test_client.core_admin.create(core, configSet=configSet)
         resp = test_client.core_admin.status(core=core)
         assert not resp.initFailures
         # core has a start time

--- a/parasol/solr/test_solr.py
+++ b/parasol/solr/test_solr.py
@@ -57,13 +57,18 @@ def test_client(request):
 
     If a test field is listed here, it will NOT be automatically cleaned up.
     """
-    client = SolrClient(**TEST_SOLR_CONNECTION)
 
-    response = client.core_admin.status(core=TEST_SOLR_CONNECTION['collection'])
+    solr_url = TEST_SOLR_CONNECTION.get('URL', None)
+    collection = TEST_SOLR_CONNECTION.get('COLLECTION', None)
+    commitWithin  = TEST_SOLR_CONNECTION.get('COMMITWITHIN', None)
+    configSet = TEST_SOLR_CONNECTION.get('CONFIGSET', None)
+
+    client = SolrClient(solr_url, collection, commitWithin=commitWithin)
+
+    response = client.core_admin.status(core=collection)
     if response.status.parasol_test:
         raise CoreExists('Test core "parasol_test" exists, aborting!')
-    client.core_admin.create(TEST_SOLR_CONNECTION['collection'],
-                             configSet='basic_configs')
+    client.core_admin.create(collection, configSet=configSet)
 
     def clean_up():
         for field in TEST_FIELDS:
@@ -73,7 +78,7 @@ def test_client(request):
         for ftype in TEST_FIELD_TYPES:
             client.schema.delete_field_type(name=ftype)
         client.core_admin.unload(
-            TEST_SOLR_CONNECTION['collection'],
+            collection,
             deleteInstanceDir=True,
             deleteIndex=True,
             deleteDataDir=True
@@ -90,8 +95,11 @@ def core_test_client(request):
     Unconditionally deletes the core named, so that any CoreAdmin API tests
     are always cleaned up on teardown.
     """
-    client = SolrClient(**TEST_SOLR_CONNECTION)
+    solr_url = TEST_SOLR_CONNECTION.get('URL', None)
+    commitWithin  = TEST_SOLR_CONNECTION.get('COMMITWITHIN', None)
     core_name = str(uuid.uuid4())
+
+    client = SolrClient(solr_url, core_name, commitWithin=commitWithin)
 
     def clean_up():
 
@@ -637,7 +645,7 @@ class TestCoreAdmin:
 
     def test_status(self, test_client):
         response = test_client.core_admin.\
-                status(core=TEST_SOLR_CONNECTION['collection'])
+                status(core=TEST_SOLR_CONNECTION['COLLECTION'])
         # no init failures happened
         assert not response.initFailures
         # status is not empty, and therefore has core info

--- a/parasol/tests/test_commands.py
+++ b/parasol/tests/test_commands.py
@@ -50,6 +50,7 @@ class TestSolrSchemaCommand:
 
         mocksolr = mocksolrclient.return_value
         mocksolr.collection = 'test-coll'
+        mocksolr.configSet = 'test_config'
         mocksolr.core_admin.ping.return_value = False
 
         cmd = solr_schema.Command()
@@ -71,7 +72,7 @@ class TestSolrSchemaCommand:
         # called once
         assert mockinput.call_count
         mocksolr.core_admin.create.assert_called_with(
-            mocksolr.collection, configSet='basic_configs')
+            mocksolr.collection, configSet='test_config')
 
         # simulate no input requested
         mockinput.reset_mock()

--- a/parasol/tests/test_commands.py
+++ b/parasol/tests/test_commands.py
@@ -7,6 +7,7 @@ import requests
 try:
     from django.core.management import call_command
     from django.core.management.base import CommandError
+    from django.test import override_settings
 
     from parasol.management.commands import solr_schema, index
 except ImportError:
@@ -45,12 +46,12 @@ class TestSolrSchemaCommand:
     @patch('parasol.management.commands.solr_schema.SolrClient')
     @patch('parasol.management.commands.solr_schema.SolrSchema')
     @patch('parasol.management.commands.solr_schema.input')
+    @override_settings(SOLR_CONNECTIONS={'default': {'CONFIGSET': 'test_config'}})
     def test_handle_core(self, mockinput, mocksolrschema, mocksolrclient):
         # using mock SolrSchema to avoid exception on get_configuration
 
         mocksolr = mocksolrclient.return_value
         mocksolr.collection = 'test-coll'
-        mocksolr.configSet = 'test_config'
         mocksolr.core_admin.ping.return_value = False
 
         cmd = solr_schema.Command()

--- a/parasol/tests/test_commands.py
+++ b/parasol/tests/test_commands.py
@@ -46,7 +46,6 @@ class TestSolrSchemaCommand:
     @patch('parasol.management.commands.solr_schema.SolrClient')
     @patch('parasol.management.commands.solr_schema.SolrSchema')
     @patch('parasol.management.commands.solr_schema.input')
-    @override_settings(SOLR_CONNECTIONS={'default': {'CONFIGSET': 'test_config'}})
     def test_handle_core(self, mockinput, mocksolrschema, mocksolrclient):
         # using mock SolrSchema to avoid exception on get_configuration
 
@@ -69,36 +68,39 @@ class TestSolrSchemaCommand:
         # simulate user says yes when asked to create core
         mockinput.reset_mock()
         mockinput.return_value = 'Y'
-        cmd.handle()
-        # called once
-        assert mockinput.call_count
-        mocksolr.core_admin.create.assert_called_with(
-            mocksolr.collection, configSet='test_config')
+        with override_settings(SOLR_CONNECTIONS=\
+            {'default': {'CONFIGSET': 'test_config'}}):
 
-        # simulate no input requested
-        mockinput.reset_mock()
-        mocksolr.reset_mock()
-        mocksolr.core_admin.ping.return_value = False
-        cmd.handle(noinput=True)
-        # input not called, but create should be called
-        mockinput.assert_not_called()
-        assert mocksolr.core_admin.create.call_count
+            cmd.handle()
+            # called once
+            assert mockinput.call_count
+            mocksolr.core_admin.create.assert_called_with(
+                mocksolr.collection, configSet='test_config')
 
-        # should work the same way from the command line
-        mockinput.reset_mock()
-        mocksolr.reset_mock()
-        mocksolr.core_admin.ping.return_value = False
-        call_command('solr_schema', noinput=True, verbosity=0)
-        # input not called, but create should be called
-        mockinput.assert_not_called()
-        assert mocksolr.core_admin.create.call_count
+            # simulate no input requested
+            mockinput.reset_mock()
+            mocksolr.reset_mock()
+            mocksolr.core_admin.ping.return_value = False
+            cmd.handle(noinput=True)
+            # input not called, but create should be called
+            mockinput.assert_not_called()
+            assert mocksolr.core_admin.create.call_count
 
-        # simulate collection does exist - no input or create
-        mocksolr.reset_mock()
-        mocksolr.core_admin.ping.return_value = True
-        cmd.handle()
-        mockinput.assert_not_called()
-        mocksolr.core_admin.create.assert_not_called()
+            # should work the same way from the command line
+            mockinput.reset_mock()
+            mocksolr.reset_mock()
+            mocksolr.core_admin.ping.return_value = False
+            call_command('solr_schema', noinput=True, verbosity=0)
+            # input not called, but create should be called
+            mockinput.assert_not_called()
+            assert mocksolr.core_admin.create.call_count
+
+            # simulate collection does exist - no input or create
+            mocksolr.reset_mock()
+            mocksolr.core_admin.ping.return_value = True
+            cmd.handle()
+            mockinput.assert_not_called()
+            mocksolr.core_admin.create.assert_not_called()
 
     @patch('parasol.management.commands.solr_schema.SolrClient')
     @patch('parasol.management.commands.solr_schema.SolrSchema')

--- a/parasol/tests/test_django.py
+++ b/parasol/tests/test_django.py
@@ -43,6 +43,8 @@ def test_django_solrclient():
         solr = SolrClient()
         assert solr.solr_url == config['URL']
         assert solr.collection == ''
+        # basic configs are respected as a default
+        assert solr.configSet == 'basic_configs'
 
     # url and collection
     config['COLLECTION'] = 'mycore'
@@ -50,6 +52,13 @@ def test_django_solrclient():
         solr = SolrClient()
         assert solr.solr_url == config['URL']
         assert solr.collection == config['COLLECTION']
+
+    # override configset
+    config['CONFIGSET'] = 'test_configs'
+    with override_settings(SOLR_CONNECTIONS={'default': config}):
+        solr = SolrClient()
+        assert solr.configSet == config['CONFIGSET']
+
 
 
 @skipif_django

--- a/parasol/tests/test_django.py
+++ b/parasol/tests/test_django.py
@@ -43,8 +43,6 @@ def test_django_solrclient():
         solr = SolrClient()
         assert solr.solr_url == config['URL']
         assert solr.collection == ''
-        # basic configs are respected as a default
-        assert solr.configSet == 'basic_configs'
 
     # url and collection
     config['COLLECTION'] = 'mycore'
@@ -52,13 +50,6 @@ def test_django_solrclient():
         solr = SolrClient()
         assert solr.solr_url == config['URL']
         assert solr.collection == config['COLLECTION']
-
-    # override configset
-    config['CONFIGSET'] = 'test_configs'
-    with override_settings(SOLR_CONNECTIONS={'default': config}):
-        solr = SolrClient()
-        assert solr.configSet == config['CONFIGSET']
-
 
 
 @skipif_django


### PR DESCRIPTION
This PR:
- [ ] refactors `test` settings to use Django style`ALLCAPS` keys
- [ ] allows settings to include a `CONFIGSET` option to specify a Solr `configSet` that is properly installed in the Solr instance's `configsets` directory