### PR TITLE
pytest plugin for solr testing in django projects

### DIFF
--- a/ci/testsettings.py
+++ b/ci/testsettings.py
@@ -25,7 +25,7 @@ SOLR_CONNECTIONS = {
         'URL': 'http://localhost:8983/solr/',
         'COLLECTION': 'parasol_test',
         # aggressive commitWithin for test only
-        'commitWithin': 750,
+        'COMMITWITHIN': 750,
         'CONFIGSET': 'basic_configs'
     },
     # default config for testing pytest plugin

--- a/ci/testsettings.py
+++ b/ci/testsettings.py
@@ -26,5 +26,10 @@ SOLR_CONNECTIONS = {
         'collection': 'parasol_test',
         # aggressive commitWithin for test only
         'commitWithin': 750
+    },
+    # default config for testing pytest plugin
+    'default': {
+        'URL': 'http://localhost:8983/solr/',
+        'COLLECTION': 'myplugin'
     }
 }

--- a/parasol/django.py
+++ b/parasol/django.py
@@ -62,6 +62,12 @@ if django:
 
             collection = default_solr.get('COLLECTION', '')
 
+            # use commit within if configured
+            commit_within = default_solr.get('COMMITWITHIN', None)
+            # passed-in value takes precedence
+            if 'commitWithin' not in kwargs and commit_within:
+                kwargs['commitWithin'] = commit_within
+
             logger.info('Connecting to default Solr %s%s', url, collection)
             super().__init__(url, collection, *args, **kwargs)
 

--- a/parasol/pytest_plugin.py
+++ b/parasol/pytest_plugin.py
@@ -1,0 +1,81 @@
+import logging
+
+import pytest
+
+try:
+    import django
+    from django.conf import settings
+    from django.test import override_settings
+except ImportError:
+    django = None
+
+from parasol import django
+from parasol.schema import SolrSchema
+
+
+logger = logging.getLogger(__name__)
+
+
+if django:
+
+    @pytest.fixture(autouse=True, scope="session")
+    def configure_django_test_solr():
+        """Automatically configure the default Solr to use a test
+        core based on the configured **SOLR_CONNECTIONS**.  Will use
+        test name if specified (using the same structure as Django
+        DATABASES), or prepend "test_" to the configured COLLECTION
+        if no test name is set. The test core will be created and
+        schema configured before starting, and unloaded after tests
+        complete.  Example configuration::
+
+            SOLR_CONNECTIONS = {
+                'default': {
+                    'URL': 'http://localhost:8983/solr/',
+                    'COLLECTION': 'myproj',
+                    'TEST': {
+                        'NAME': 'testproj',
+                        }
+                }
+            }
+
+        """
+
+        if 'TEST' in settings.SOLR_CONNECTIONS['default'] and \
+          'NAME' in settings.SOLR_CONNECTIONS['default']['TEST']:
+            test_collection = settings.SOLR_CONNECTIONS['default']['TEST']['NAME']
+        else:
+            test_collection = 'test_%s'% settings.SOLR_CONNECTIONS['default']['COLLECTION']
+
+        test_config = settings.SOLR_CONNECTIONS['default'].copy()
+        test_config['COLLECTION'] = test_collection
+
+        logger.info('Configuring Solr for tests %s%s',
+                    test_config['URL'], test_collection)
+
+        with override_settings(SOLR_CONNECTIONS={'default': test_config}):
+            # reload core before and after to ensure field list is accurate
+            solr = django.SolrClient(commitWithin=10)
+            response = solr.core_admin.status(core=test_collection)
+            if not response.status.get(test_collection, None):
+                solr.core_admin.create(test_collection, configSet='basic_configs')
+
+            try:
+                # if a schema is configured, update the test core
+                schema_config = SolrSchema.get_configuration()
+                schema_config.configure_fieldtypes(solr)
+                schema_config.configure_fields(solr)
+            except Exception:
+                pass
+
+            # yield settings so tests run with overridden solr connection
+            yield settings
+
+            # clear out any data indexed in test collection
+            solr.update.delete_by_query('*:*')
+            # and unload
+            solr.core_admin.unload(
+                test_collection,
+                deleteInstanceDir=True,
+                deleteIndex=True,
+                deleteDataDir=True
+            )

--- a/parasol/solr/__init__.py
+++ b/parasol/solr/__init__.py
@@ -1,3 +1,2 @@
 
 from parasol.solr.client import SolrClient
-

--- a/parasol/tests/test_django.py
+++ b/parasol/tests/test_django.py
@@ -51,6 +51,16 @@ def test_django_solrclient():
         assert solr.solr_url == config['URL']
         assert solr.collection == config['COLLECTION']
 
+    # commit within option
+    config['COMMITWITHIN'] = 750
+    with override_settings(SOLR_CONNECTIONS={'default': config}):
+        solr = SolrClient()
+        assert solr.commitWithin == 750
+
+        # but passed in value takes precedence
+        solr = SolrClient(commitWithin=7339)
+        assert solr.commitWithin == 7339
+
 
 @skipif_django
 def test_no_django_solrclient():

--- a/parasol/tests/test_pytest_plugin.py
+++ b/parasol/tests/test_pytest_plugin.py
@@ -21,25 +21,33 @@ def test_configure_django_test_solr(testdir):
     """Sanity check pytest solr fixture."""
 
     solr_url = settings.SOLR_CONNECTIONS['default']['URL']
-    solr_collection = settings.SOLR_CONNECTIONS['default']['COLLECTION']
+    solr_test_collection = settings.SOLR_CONNECTIONS['default']['TEST']['COLLECTION']
+    solr_commit_within = settings.SOLR_CONNECTIONS['default']['TEST']['COMMITWITHIN']
+
+    # NOTE: can't figure out how to get the plugin test to use
+    # test-local test settings, so testing against project
+    # testsettings for now
 
     # create a temporary pytest test file
     testdir.makepyfile(
         """
         from parasol.django import SolrClient
 
-        # pytest_plugins = "parasol.pytest_plugin"
+        # causes "Plugin already registered" error on travis...
+        pytest_plugins = "parasol.pytest_plugin"
 
         def test_solr_client():
             solr = SolrClient()
             # solr client should use test config
             assert solr.solr_url == '%s'
-            test_collection = 'test_%s'
+            test_collection = '%s'
             assert solr.collection == test_collection
+            # should get test config for commit within
+            assert solr.commitWithin == %d
             # core should exist
             assert solr.core_admin.status(core=test_collection)
 
-    """ % (solr_url, solr_collection)
+    """ % (solr_url, solr_test_collection, solr_commit_within)
     )
 
     # run all tests with pytest with all pytest-django plugins turned off

--- a/parasol/tests/test_pytest_plugin.py
+++ b/parasol/tests/test_pytest_plugin.py
@@ -34,7 +34,7 @@ def test_configure_django_test_solr(testdir):
         from parasol.django import SolrClient
 
         # causes "Plugin already registered" error on travis...
-        pytest_plugins = "parasol.pytest_plugin"
+        # pytest_plugins = "parasol.pytest_plugin"
 
         def test_solr_client():
             solr = SolrClient()

--- a/parasol/tests/test_pytest_plugin.py
+++ b/parasol/tests/test_pytest_plugin.py
@@ -28,7 +28,7 @@ def test_configure_django_test_solr(testdir):
         """
         from parasol.django import SolrClient
 
-        pytest_plugins = "parasol.pytest_plugin"
+        # pytest_plugins = "parasol.pytest_plugin"
 
         def test_solr_client():
             solr = SolrClient()

--- a/parasol/tests/test_pytest_plugin.py
+++ b/parasol/tests/test_pytest_plugin.py
@@ -1,0 +1,47 @@
+"""
+Test pytest plugin fixture for django
+"""
+import uuid
+
+import pytest
+try:
+    from django.conf import settings
+    from django.test import override_settings
+except ImportError:
+    pass
+
+from parasol.tests.utils import skipif_no_django
+
+
+pytest_plugins = "pytester"
+
+
+@skipif_no_django
+def test_configure_django_test_solr(testdir):
+    """Sanity check pytest solr fixture."""
+
+    solr_url = settings.SOLR_CONNECTIONS['default']['URL']
+    solr_collection = settings.SOLR_CONNECTIONS['default']['COLLECTION']
+
+    # create a temporary pytest test file
+    testdir.makepyfile(
+        """
+        from parasol.django import SolrClient
+
+        def test_solr_client():
+            solr = SolrClient()
+            # solr client should use test config
+            assert solr.solr_url == '%s'
+            test_collection = 'test_%s'
+            assert solr.collection == test_collection
+            # core should exist
+            assert solr.core_admin.status(core=test_collection)
+
+    """ % (solr_url, solr_collection)
+    )
+
+    # run all tests with pytest with all pytest-django plugins turned off
+    # result = testdir.runpytest('-p', 'no:django')
+    result = testdir.runpytest_subprocess('--capture', 'no') #, '-p', 'no:django')
+    # check that test case passed
+    result.assert_outcomes(passed=1)

--- a/parasol/tests/test_pytest_plugin.py
+++ b/parasol/tests/test_pytest_plugin.py
@@ -28,6 +28,8 @@ def test_configure_django_test_solr(testdir):
         """
         from parasol.django import SolrClient
 
+        pytest_plugins = "parasol.pytest_plugin"
+
         def test_solr_client():
             solr = SolrClient()
             # solr client should use test config

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=testsettings
+addopts=-p no:parasol
 # look for tests in standard django test location
 python_files = "**/tests.py" "**/test_*.py"

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        "Framework :: Pytest",
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,10 @@ setup(
         'Programming Language :: Python :: 3.6'
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Database',
-    ]
+    ],
+    entry_points={
+        'pytest11': [
+            'parasol = parasol.pytest_plugin',
+        ]
+    },
 )


### PR DESCRIPTION
Adds a pytest plugin with a fixture to automatically swap default settings used by `parasol.django.SolrClient` to use a test collection, either explicitly named or named based on the configured collection. The fixture creates the collection if it doesn't exist, and updates the schema if the project has a schema configuration. It clears data and unloads the collection after tests complete.

There is a unit test for the pytest fixture, but it does not currently cover all cases.