### PR TITLE
Add __in filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 CHANGELOG
 =========
 
+0.3
+---
+
+* Add support for `__in` queries with `filter` method of SolrQuerySet
+* Add support for searching for missing/unset values in `filter` method of
+  SolrQuerySet.
 
 0.2
 ---

--- a/parasolr/query.py
+++ b/parasolr/query.py
@@ -38,7 +38,7 @@ class SolrQuerySet:
     filter_qs = []
     field_list = []
     highlight_field = None
-    facet_field = []
+    facet_field_list = []
     facet_opts = {}
     highlight_opts = {}
     raw_params = {}
@@ -109,13 +109,15 @@ class SolrQuerySet:
             for key, val in self.highlight_opts.items():
                 query_opts['hl.%s' % key] = val
 
-        if self.facet_field:
+        if self.facet_field_list:
             query_opts.update({
                 'facet': True,
-                'facet.field': self.facet_field
+                'facet.field': self.facet_field_list
             })
             for key, val in self.facet_opts.items():
-                query_opts['facet.%s' % key] = val
+                # use key as is if it starts with "f."
+                # (field-specific facet options); otherwise prepend "facet."
+                query_opts[key if key.startswith('f.') else 'facet.%s' % key] = val
 
         # include any raw query parameters
         query_opts.update(self.raw_params)
@@ -274,9 +276,28 @@ class SolrQuerySet:
         qs_copy = self._clone()
 
         # cast args tuple to list for consistency with other iterable fields
-        qs_copy.facet_field = list(args)
+        qs_copy.facet_field_list = list(args)
         # add other kwargs to be prefixed in query_opts
         qs_copy.facet_opts.update(kwargs)
+
+        return qs_copy
+
+    def facet_field(self, field: str, **kwargs) -> 'SolrQuerySet':
+        """
+        Request faceting for a single field. Returns a new SolrQuerySet
+        with Solr faceting enabled and the field added to
+        the list of facet fields.  Any keyword arguments will be set
+        as field-specific facet  configurations.
+        """
+        qs_copy = self._clone()
+        # add the field to the list of facet fields
+        qs_copy.facet_field_list.append(field)
+        # prefix any keyword args with the field name
+        # (facet. prefix added in query_opts)
+
+        qs_copy.facet_opts.update({
+            'f.%s.facet.%s' % (field, opt) : value
+            for opt, value in kwargs.items()})
 
         return qs_copy
 
@@ -391,9 +412,8 @@ class SolrQuerySet:
         qs_copy.field_list = list(self.field_list)
         qs_copy.highlight_opts = dict(self.highlight_opts)
         qs_copy.raw_params = dict(self.raw_params)
-        qs_copy.facet_field = list(self.facet_field)
+        qs_copy.facet_field_list = list(self.facet_field_list)
         qs_copy.facet_opts = dict(self.facet_opts)
-
 
         return qs_copy
 

--- a/parasolr/query.py
+++ b/parasolr/query.py
@@ -284,7 +284,7 @@ class SolrQuerySet:
 
         return qs_copy
 
-    def facet_field(self, field: str, ex: str='', **kwargs) -> 'SolrQuerySet':
+    def facet_field(self, field: str, exclude: str='', **kwargs) -> 'SolrQuerySet':
         """
         Request faceting for a single field. Returns a new SolrQuerySet
         with Solr faceting enabled and the field added to
@@ -297,8 +297,8 @@ class SolrQuerySet:
         """
         qs_copy = self._clone()
         # append exclude tag if specified
-        qs_copy.facet_field_list.append('{!ex=%s}%s' % (ex, field)
-                                         if ex else field)
+        qs_copy.facet_field_list.append('{!ex=%s}%s' % (exclude, field)
+                                         if exclude else field)
         # prefix any keyword args with the field name
         # (facet. prefix added in query_opts)
 

--- a/parasolr/tests/test_query.py
+++ b/parasolr/tests/test_query.py
@@ -423,19 +423,16 @@ class TestSolrQuerySet:
         assert SolrQuerySet._lookup_to_filter('item_type', 'work') == \
             'item_type:work'
         # simple key-value with empty/null
-        assert SolrQuerySet._lookup_to_filter('item_type', '') == \
+        assert SolrQuerySet._lookup_to_filter('item_type__exists', True) == \
+            'item_type:[* TO *]'
+        assert SolrQuerySet._lookup_to_filter('item_type__exists', False) == \
             '-item_type:[* TO *]'
         # simple __in query
         assert SolrQuerySet._lookup_to_filter('item_type__in', ['a', 'b']) == \
             'item_type:(a OR b)'
         # complex __in query with a negation
         assert SolrQuerySet._lookup_to_filter('item_type__in', ['a', 'b', '']) == \
-            '-(item_type:[* TO *] -item_type:(a OR b))'
-
-        # check edge case as 0 should probably not be treated as false
-        assert SolrQuerySet._lookup_to_filter('item_type', 0) == \
-            'item_type:0'
-
+            '-(item_type:[* TO *] OR -item_type:(a OR b))'
 
     def test_iter(self):
         mocksolr = Mock(spec=SolrClient)

--- a/parasolr/tests/test_query.py
+++ b/parasolr/tests/test_query.py
@@ -245,7 +245,7 @@ class TestSolrQuerySet:
         assert 'f.sort.facet.missing' in facet_sqs.facet_opts
 
         # facet with ex field for exclusions
-        facet_sqs = sqs.facet_field('sort', ex='sort')
+        facet_sqs = sqs.facet_field('sort', exclude='sort')
         assert '{!ex=sort}sort' in facet_sqs.facet_field_list
 
 

--- a/parasolr/tests/test_query.py
+++ b/parasolr/tests/test_query.py
@@ -419,8 +419,23 @@ class TestSolrQuerySet:
         assert 'name:hem*' in search_sqs.search_qs
 
     def test__lookup_to_filter(self):
+        # simple key-value
         assert SolrQuerySet._lookup_to_filter('item_type', 'work') == \
             'item_type:work'
+        # simple key-value with empty/null
+        assert SolrQuerySet._lookup_to_filter('item_type', '') == \
+            '-item_type:[* TO *]'
+        # simple __in query
+        assert SolrQuerySet._lookup_to_filter('item_type__in', ['a', 'b']) == \
+            'item_type:(a OR b)'
+        # complex __in query with a negation
+        assert SolrQuerySet._lookup_to_filter('item_type__in', ['a', 'b', '']) == \
+            '-(item_type:[* TO *] -item_type:(a OR b))'
+
+        # check edge case as 0 should probably not be treated as false
+        assert SolrQuerySet._lookup_to_filter('item_type', 0) == \
+            'item_type:0'
+
 
     def test_iter(self):
         mocksolr = Mock(spec=SolrClient)

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ DJANGO_SETTINGS_MODULE=testsettings
 addopts=-p no:parasolr
 # look for tests in standard django test location
 python_files = "**/tests.py" "**/test_*.py"
+# set testpath for collection speed up
+testpath = parasolr


### PR DESCRIPTION
This PR adds support for the `__in` filter in queries and also includes logic (that I'd love to simplify but haven't found a way yet) for complex searches on missing or empty fields.

Supplies functionality for Princeton-CDH/mep-django#198.