### PR TITLE
 Adds stats functionality to Parasolr (Aliased/Unaliased)

### DIFF
--- a/parasolr/query/aliased_queryset.py
+++ b/parasolr/query/aliased_queryset.py
@@ -120,10 +120,10 @@ class AliasedSolrQuerySet(SolrQuerySet):
         """Extend :meth:`parasolr.query.queryset.SolrQuerySet.get_stats` to
         return return aliased field names for field_list keys."""
         stats = super().get_stats()
-        for field in stats['stats_fields']:
-            stats['stats_fields'][self.reverse_aliases.get(field, field)] \
-                = stats['stats_fields'].pop(field)
-
+        stats['stats_fields'] = {
+            self.reverse_aliases.get(field, field): val
+            for field, val in stats['stats_fields'].items()
+        }
         return stats
 
     # NOTE: may want to do the same for highlighting also eventually,

--- a/parasolr/query/aliased_queryset.py
+++ b/parasolr/query/aliased_queryset.py
@@ -65,6 +65,12 @@ class AliasedSolrQuerySet(SolrQuerySet):
         args = self._unalias_args(*args)
         return super().facet(*args, **kwargs)
 
+    def stats(self, *args, **kwargs) -> 'AliasedSolrQuerySet':
+        """Extend :methd:`parasolr.query.queryset.SolrQuerySet.stats
+        to support using aliased field names in args."""
+        args = self._unalias_args(*args)
+        return super().stats(*args, **kwargs)
+
     def facet_field(self, field: str, exclude: str='', **kwargs) -> 'AlaisedSolrQuerySet':
         '''Extend :meth:`parasolr.query.queryset.SolrQuerySet.facet_field``
         to support using aliased field names for field parameter.'''
@@ -90,13 +96,13 @@ class AliasedSolrQuerySet(SolrQuerySet):
     # also method does not need to be extended, since it runs through only
 
     def highlight(self, field: str, **kwargs) -> 'AliasedSolrQuerySet':
-        '''Extend :meth:`parasolr.query.queryset.SolrQuerySet.highlight``
+        '''Extend :meth:`parasolr.query.queryset.SolrQuerySet.highlight`
         to support using aliased field names in kwargs.'''
         field = self.field_aliases.get(field, field)
         return super().highlight(field, **kwargs)
 
     def get_facets(self) -> Dict[str, int]:
-        '''Extend :meth:`parasolr.query.queryset.SolrQuerySet.get_facets``
+        '''Extend :meth:`parasolr.query.queryset.SolrQuerySet.get_facets`
         to use aliased field names for facet and range facet keys.'''
         facets = super().get_facets()
 
@@ -109,6 +115,16 @@ class AliasedSolrQuerySet(SolrQuerySet):
             }
 
         return facets
+
+    def get_stats(self) -> Dict[str, Dict]:
+        """Extend :meth:`parasolr.query.queryset.SolrQuerySet.get_stats` to
+        return return aliased field names for field_list keys."""
+        stats = super().get_stats()
+        for field in stats['stats_fields']:
+            stats['stats_fields'][self.reverse_aliases.get(field, field)] \
+                = stats['stats_fields'].pop(field)
+
+        return stats
 
     # NOTE: may want to do the same for highlighting also eventually,
     # but no immediate need and it's structured differently so

--- a/parasolr/query/queryset.py
+++ b/parasolr/query/queryset.py
@@ -203,7 +203,7 @@ class SolrQuerySet:
             return qr.stats
         query_opts = self.query_opts()
         query_opts['rows'] = 0
-        query_opts['h1'] = False
+        query_opts['hl'] = False
 
         return self.solr.query(**query_opts).stats
 

--- a/parasolr/query/queryset.py
+++ b/parasolr/query/queryset.py
@@ -17,7 +17,7 @@ which will automatically initialize a new :class:`parasolr.django.SolrClient`
 if one is not passed in.
 """
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from parasolr.solr import SolrClient
 from parasolr.solr.client import QueryResponse
@@ -39,8 +39,10 @@ class SolrQuerySet:
     field_list = []
     highlight_field = None
     facet_field_list = []
+    stats_field_list = []
     range_facet_fields = []
     facet_opts = {}
+    stats_opts = {}
     highlight_opts = {}
     raw_params = {}
 
@@ -82,30 +84,8 @@ class SolrQuerySet:
         self._result_cache = self.solr.query(**query_opts)
         return [doc.as_dict() for doc in self._result_cache.docs]
 
-    def query_opts(self) -> Dict[str, str]:
-        """Construct query options based on current queryset configuration.
-        Includes filter queries, start and rows, sort, and search query.
-        """
-        query_opts = {
-            'start': self.start,
-        }
-
-        if self.filter_qs:
-            query_opts['fq'] = self.filter_qs
-        if self.stop:
-            query_opts['rows'] = self.stop - self.start
-        if self.sort_options:
-            query_opts['sort'] = ','.join(self.sort_options)
-
-        # main query; if no query is defined, find everything
-        if self.search_qs:
-            query_opts['q'] = self._search_op.join(self.search_qs)
-        else:
-            query_opts['q'] = '*:*'
-
-        if self.field_list:
-            query_opts['fl'] = ','.join(self.field_list)
-
+    def _configure_highlighting(self, query_opts: Dict) -> None:
+        """Configure highlighting attributes on query_opts."""
         if self.highlight_field:
             query_opts.update({
                 'hl': True,
@@ -114,6 +94,8 @@ class SolrQuerySet:
             for key, val in self.highlight_opts.items():
                 query_opts['hl.%s' % key] = val
 
+    def _configure_faceting(self, query_opts: Dict) -> None:
+        """Configure faceting attributes on query_opts."""
         if self.facet_field_list or self.range_facet_fields:
             query_opts.update({
                 'facet': True,
@@ -123,10 +105,56 @@ class SolrQuerySet:
             for key, val in self.facet_opts.items():
                 # use key as is if it starts with "f."
                 # (field-specific facet options); otherwise prepend "facet."
-                query_opts[key if key.startswith('f.') else 'facet.%s' % key] = val
+                query_opts[key if key.startswith('f.')
+                           else 'facet.%s' % key] = val
+
+    def _configure_stats(self, query_opts: Dict) -> None:
+        """Configure faceting attributes on query_opts."""
+        if self.stats_field_list:
+            query_opts.update({
+                'stats': True,
+                'stats.field': self.stats_field_list
+            })
+            for key, val in self.stats_opts.items():
+                # use key as if it starts with stats, otherwise prepend
+                query_opts[key if key.startswith('stats')
+                           else 'stats.%s' % key] = val
+
+    def query_opts(self) -> Dict[str, str]:
+        """Construct query options based on current queryset configuration.
+        Includes filter queries, start and rows, sort, and search query.
+        """
+        query_opts = {
+            'start': self.start,
+        }
+
+        # Opts that need to be filtered for empty
+        query_opts['fq'] = self.filter_qs if self.filter_qs else ''
+        query_opts['fl'] = ','.join(self.field_list)
+        query_opts['sort'] = ','.join(self.sort_options)
+
+        # use stop if set to limit row numbers
+        if self.stop:
+            query_opts['rows'] = self.stop - self.start
+
+        # main query; if no query is defined, find everything
+        q = self._search_op.join(self.search_qs)
+        query_opts['q'] = q if q else '*:*'
+
+        # highlighting
+        self._configure_highlighting(query_opts)
+
+        # faceting
+        self._configure_faceting(query_opts)
+
+        # stats
+        self._configure_stats(query_opts)
 
         # include any raw query parameters
         query_opts.update(self.raw_params)
+
+        # remove any empty string values
+        query_opts = {k: v for k, v in query_opts.items() if v != ''}
 
         return query_opts
 
@@ -167,6 +195,17 @@ class SolrQuerySet:
         # setting these by dictionary assignment, because conflicting
         # kwargs results in a Python exception
         return self.solr.query(**query_opts).facet_counts
+
+    def get_stats(self) -> Optional[Dict[str, 'ParasolrDict']]:
+        """Return a dictionary of stats information in Solr format."""
+        if self._result_cache is not None:
+            qr = QueryResponse(self._result_cache)
+            return qr.stats
+        query_opts = self.query_opts()
+        query_opts['rows'] = 0
+        query_opts['h1'] = False
+
+        return self.solr.query(**query_opts).stats
 
     @staticmethod
     def _lookup_to_filter(key: str, value: Any, tag: str='') -> str:
@@ -290,7 +329,7 @@ class SolrQuerySet:
             qs = queryset.facet('person_type', 'age')
             qs = qs.facet('item_type')
 
-        would result in `item_type` being the only facet field.
+        would result in ``item_type`` being the only facet field.
         """
         qs_copy = self._clone()
 
@@ -300,6 +339,34 @@ class SolrQuerySet:
         qs_copy.facet_opts.update(kwargs)
 
         return qs_copy
+
+    def stats(self, *args: str, **kwargs) -> 'SolrQuerySet':
+        """
+        Request stats for specified fields. Returns a new SolrQuerySet
+        with Solr faceting enabled and stats.field parameter set.
+
+        Subsequent calls will reset the stats.field to the last set of
+        args in the chain.
+
+        For example::
+
+            qs = queryset.stats('person_type', 'age')
+            qs = qs.stats('account_start_i')
+
+        would result in ``account_start_i`` being the only facet field.
+
+        Any kwargs will be prepended with ``stats.``. You may also pass local
+        parameters along with field names, i.e. ``{!ex=filterA}account_start_i``.
+        """
+
+        qs_copy = self._clone()
+        # cast args tuple to list for consistency with other iterable fields
+        qs_copy.stats_field_list = list(args)
+        # add other kwargs to be prefixed query_opts
+        qs_copy.stats_opts.update(kwargs)
+
+        return qs_copy
+
 
     def facet_field(self, field: str, exclude: str='', **kwargs) -> 'SolrQuerySet':
         """
@@ -471,6 +538,9 @@ class SolrQuerySet:
         qs_copy.raw_params = dict(self.raw_params)
         qs_copy.facet_field_list = list(self.facet_field_list)
         qs_copy.facet_opts = dict(self.facet_opts)
+        qs_copy.stats_field_list = list(self.stats_field_list)
+        qs_copy.stats_opts = dict(self.stats_opts)
+
 
         return qs_copy
 

--- a/parasolr/query/queryset.py
+++ b/parasolr/query/queryset.py
@@ -83,7 +83,7 @@ class SolrQuerySet:
         self._result_cache = self.solr.query(**query_opts)
         return [doc.as_dict() for doc in self._result_cache.docs]
 
-    def _configure_highlighting(self, query_opts: Dict) -> None:
+    def _set_highlighting_opts(self, query_opts: Dict) -> None:
         """Configure highlighting attributes on query_opts. Modifies
         dictionary directly."""
         if self.highlight_field:
@@ -94,7 +94,7 @@ class SolrQuerySet:
             for key, val in self.highlight_opts.items():
                 query_opts['hl.%s' % key] = val
 
-    def _configure_faceting(self, query_opts: Dict) -> None:
+    def _set_faceting_opts(self, query_opts: Dict) -> None:
         """Configure faceting attributes directly on query_opts. Modifies
         dictionary directly."""
         if self.facet_field_list or self.range_facet_fields:
@@ -109,8 +109,8 @@ class SolrQuerySet:
                 query_opts[key if key.startswith('f.')
                            else 'facet.%s' % key] = val
 
-    def _configure_stats(self, query_opts: Dict) -> None:
-        """Configure faceting attributes directly on query_opts. Modifies
+    def _set_stats_opts(self, query_opts: Dict) -> None:
+        """Configure stats attributes directly on query_opts. Modifies
         dictionary directly."""
         if self.stats_field_list:
             query_opts.update({
@@ -142,13 +142,13 @@ class SolrQuerySet:
             query_opts['rows'] = self.stop - self.start
 
         # highlighting
-        self._configure_highlighting(query_opts)
+        self._set_highlighting_opts(query_opts)
 
         # faceting
-        self._configure_faceting(query_opts)
+        self._set_faceting_opts(query_opts)
 
         # stats
-        self._configure_stats(query_opts)
+        self._set_stats_opts(query_opts)
 
         # include any raw query parameters
         query_opts.update(self.raw_params)

--- a/parasolr/query/queryset.py
+++ b/parasolr/query/queryset.py
@@ -362,11 +362,10 @@ class SolrQuerySet:
         qs_copy = self._clone()
         # cast args tuple to list for consistency with other iterable fields
         qs_copy.stats_field_list = list(args)
-        # add other kwargs to be prefixed query_opts
+        # add other kwargs to be prefixed in query_opts
         qs_copy.stats_opts.update(kwargs)
 
         return qs_copy
-
 
     def facet_field(self, field: str, exclude: str='', **kwargs) -> 'SolrQuerySet':
         """

--- a/parasolr/query/tests/test_aliased_queryset.py
+++ b/parasolr/query/tests/test_aliased_queryset.py
@@ -1,3 +1,4 @@
+import copy
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -194,6 +195,8 @@ class TestAliasedSolrQuerySet(TestCase):
     def test_get_stats(self, mock_get_stats):
 
         sample_stats = {
+            # In setup for tests, year_i is aliased to year and
+            # start_i is aliased to start
             'stats_fields': {
                 'year_i': {
                     'min': 1918.0,
@@ -205,14 +208,16 @@ class TestAliasedSolrQuerySet(TestCase):
                 }
             }
         }
-        mock_get_stats.return_value = sample_stats
+        # Deepcopy to avoid the dictionaries being passed by reference
+        # so we can check against the original object later
+        mock_get_stats.return_value = copy.deepcopy(sample_stats)
         stats = self.mysqs.get_stats()
         # aliased field is changed to unaliased form
         assert 'year_i' not in stats['stats_fields']
         assert 'year' in stats['stats_fields']
-        # value of field is preserved without change
+        # value of field is preserved without chang
         assert stats['stats_fields']['year'] \
-            == sample_stats['stats_fields']['year']
+            == sample_stats['stats_fields']['year_i']
         # unaliased field is left alone
         assert 'start_i' in stats['stats_fields']
         assert stats['stats_fields']['start_i'] \

--- a/parasolr/query/tests/test_aliased_queryset.py
+++ b/parasolr/query/tests/test_aliased_queryset.py
@@ -196,24 +196,12 @@ class TestAliasedSolrQuerySet(TestCase):
         sample_stats = {
             'stats_fields': {
                 'year_i': {
-                    'min': 1919.0,
-                    'max': 2018.0,
-                    'count': 6506,
-                    'missing': 10873,
-                    'sum': 1.2550833E7,
-                    'sumofSquares': 2.4212293087E10,
-                    'mean': 1929.116661543191,
-                    'stddev': 6.466735718386481
+                    'min': 1918.0,
+                    'max': 1998.0
                 },
                 'start_i': {
                     'min': 1919.0,
-                    'max': 2018.0,
-                    'count': 6506,
-                    'missing': 10873,
-                    'sum': 1.2550833E7,
-                    'sumofSquares': 2.4212293087E10,
-                    'mean': 1929.116661543191,
-                    'stddev': 6.466735718386481
+                    'max': 2020.0,
                 }
             }
         }

--- a/parasolr/query/tests/test_aliased_queryset.py
+++ b/parasolr/query/tests/test_aliased_queryset.py
@@ -196,7 +196,7 @@ class TestAliasedSolrQuerySet(TestCase):
 
         sample_stats = {
             # In setup for tests, year_i is aliased to year and
-            # start_i is aliased to start
+            # start_i is unaliased
             'stats_fields': {
                 'year_i': {
                     'min': 1918.0,

--- a/parasolr/solr/client.py
+++ b/parasolr/solr/client.py
@@ -47,6 +47,7 @@ class QueryResponse:
         self.start = int(response.response.start)
         self.docs = response.response.docs
         self.params = response.responseHeader.params
+        self.stats = response.stats if 'stats' in response else {}
         self.facet_counts = {}
         if 'docs' in response.response:
             self.docs = response.response.docs

--- a/parasolr/solr/client.py
+++ b/parasolr/solr/client.py
@@ -59,7 +59,7 @@ class QueryResponse:
         # convert).
 
     def _process_facet_counts(self, facet_counts: AttrDict) \
-            -> AttrDict:
+            -> OrderedDict:
         """Convert facet_fields and facet_ranges to OrderedDict.
 
         Args:

--- a/parasolr/solr/tests/test_client.py
+++ b/parasolr/solr/tests/test_client.py
@@ -67,12 +67,27 @@ class TestQueryResponse:
                         }
                     }
             },
+            'stats': {
+                'stats_fields': {
+                    'accoount_start_i': {
+                        'min': 1919.0,
+                        'max': 2018.0,
+                        'count': 6506,
+                        'missing': 10873,
+                        'sum': 1.2550833E7,
+                        'sumofSquares': 2.4212293087E10,
+                        'mean': 1929.116661543191,
+                        'stddev': 6.466735718386481
+                    }
+                }
+            }
         })
         qr = QueryResponse(response)
         assert qr.params == response.responseHeader.params
         assert qr.start == response.response.start
         assert qr.docs == response.response.docs
         assert qr.numFound == response.response.numFound
+        assert qr.stats == response.stats
         assert isinstance(qr.facet_counts['facet_fields']['A'],
                           OrderedDict)
         assert isinstance(qr.facet_counts['facet_ranges']['A']['counts'],

--- a/parasolr/solr/tests/test_client.py
+++ b/parasolr/solr/tests/test_client.py
@@ -69,15 +69,9 @@ class TestQueryResponse:
             },
             'stats': {
                 'stats_fields': {
-                    'accoount_start_i': {
+                    'account_start_i': {
                         'min': 1919.0,
                         'max': 2018.0,
-                        'count': 6506,
-                        'missing': 10873,
-                        'sum': 1.2550833E7,
-                        'sumofSquares': 2.4212293087E10,
-                        'mean': 1929.116661543191,
-                        'stddev': 6.466735718386481
                     }
                 }
             }


### PR DESCRIPTION
Adds:

- `stats` method to `Queryset` and `AliasedQuerySet`
- `get_stats` method to `Queryset` and `AliasedQuerySet`
- refactors `query_opts` to lower complexity
- add `stats` property to `QueryResponse`