### PR TITLE
add EmptySolrQuerySet class

### DIFF
--- a/parasolr/query/__init__.py
+++ b/parasolr/query/__init__.py
@@ -1,2 +1,3 @@
 from parasolr.query.queryset import SolrQuerySet
+from parasolr.query.queryset import EmptySolrQuerySet
 from parasolr.query.aliased_queryset import AliasedSolrQuerySet

--- a/parasolr/query/__init__.py
+++ b/parasolr/query/__init__.py
@@ -1,3 +1,2 @@
-from parasolr.query.queryset import SolrQuerySet
-from parasolr.query.queryset import EmptySolrQuerySet
+from parasolr.query.queryset import SolrQuerySet, EmptySolrQuerySet
 from parasolr.query.aliased_queryset import AliasedSolrQuerySet

--- a/parasolr/query/queryset.py
+++ b/parasolr/query/queryset.py
@@ -596,3 +596,24 @@ class SolrQuerySet:
         # single item
         qs_copy.set_limits(k, k + 1)
         return qs_copy.get_results()[0]
+
+
+class InstanceCheckMeta(type):
+    def __instancecheck__(self, instance):
+        # allows for SolrQuerySets that are empty to behave as EmptySolrQuerySet
+        # checks that result cache is empty using __bool__
+        return isinstance(instance, SolrQuerySet) and not instance
+
+
+class EmptySolrQuerySet(metaclass=InstanceCheckMeta):
+    """
+    Marker class that can be used to check if a given queryset is empty via
+    :meth:`isinstance`::
+
+        assert isinstance(SolrQuerySet().none(), EmptySolrQuerySet) -> True
+        assert isinstance(queryset, EmptySolrQuerySet) # True if empty
+    """
+
+    def __init__(self, *args, **kwargs):
+        raise TypeError("EmptySolrQuerySet can't be instantiated")
+

--- a/parasolr/query/queryset.py
+++ b/parasolr/query/queryset.py
@@ -211,7 +211,7 @@ class SolrQuerySet:
             return response.stats
 
     @staticmethod
-    def _lookup_to_filter(key: str, value: Any, tag: str='') -> str:
+    def _lookup_to_filter(key: str, value: Any, tag: str = '') -> str:
         """Convert keyword/value argument, with optional lookups separated by
         ``__``, including: in and exists. Field names should *NOT* include
         double-underscores by convention. Accepts an optional tag argument
@@ -274,7 +274,7 @@ class SolrQuerySet:
 
         return solr_query
 
-    def filter(self, *args, tag: str='', **kwargs) -> 'SolrQuerySet':
+    def filter(self, *args, tag: str = '', **kwargs) -> 'SolrQuerySet':
         """
         Return a new SolrQuerySet with Solr filter queries added.
         Multiple filters can be combined either in a single
@@ -315,7 +315,8 @@ class SolrQuerySet:
         # any args are treated as filter queries without modification
         qs_copy.filter_qs.extend(args)
         for key, value in kwargs.items():
-            qs_copy.filter_qs.append(self._lookup_to_filter(key, value, tag=tag))
+            qs_copy.filter_qs.append(
+                self._lookup_to_filter(key, value, tag=tag))
         return qs_copy
 
     def facet(self, *args: str, **kwargs) -> 'SolrQuerySet':
@@ -370,7 +371,7 @@ class SolrQuerySet:
 
         return qs_copy
 
-    def facet_field(self, field: str, exclude: str='', **kwargs) -> 'SolrQuerySet':
+    def facet_field(self, field: str, exclude: str = '', **kwargs) -> 'SolrQuerySet':
         """
         Request faceting for a single field. Returns a new SolrQuerySet
         with Solr faceting enabled and the field added to
@@ -389,7 +390,7 @@ class SolrQuerySet:
         # (facet. prefix added in query_opts)
 
         qs_copy.facet_opts.update({
-            'f.%s.facet.%s' % (field, opt) : value
+            'f.%s.facet.%s' % (field, opt): value
             for opt, value in kwargs.items()})
 
         return qs_copy
@@ -409,7 +410,7 @@ class SolrQuerySet:
 
         # configure facet options for this field (start, end, gap)
         qs_copy.facet_opts.update({
-            'f.%s.facet.range.%s' % (field, opt) : value
+            'f.%s.facet.range.%s' % (field, opt): value
             for opt, value in kwargs.items()})
         return qs_copy
 
@@ -596,6 +597,12 @@ class SolrQuerySet:
         # single item
         qs_copy.set_limits(k, k + 1)
         return qs_copy.get_results()[0]
+
+
+# EmptySolrQuerySet instance checking is adapted from Django's solution:
+# https://github.com/django/django/blob/master/django/db/models/query.py#L1313-L1325
+# see also:
+# https://docs.djangoproject.com/en/2.2/ref/models/querysets/#none
 
 
 class InstanceCheckMeta(type):

--- a/parasolr/query/queryset.py
+++ b/parasolr/query/queryset.py
@@ -601,7 +601,7 @@ class SolrQuerySet:
 class InstanceCheckMeta(type):
     def __instancecheck__(self, instance):
         # allows for SolrQuerySets that are empty to behave as EmptySolrQuerySet
-        # checks that result cache is empty using __bool__
+        # checks that queryset is empty using __bool__
         return isinstance(instance, SolrQuerySet) and not instance
 
 
@@ -616,4 +616,3 @@ class EmptySolrQuerySet(metaclass=InstanceCheckMeta):
 
     def __init__(self, *args, **kwargs):
         raise TypeError("EmptySolrQuerySet can't be instantiated")
-

--- a/parasolr/query/tests/test_queryset.py
+++ b/parasolr/query/tests/test_queryset.py
@@ -5,7 +5,7 @@ import pytest
 
 from parasolr.solr import SolrClient
 from parasolr.solr.client import QueryResponse, ParasolrDict
-from parasolr.query import SolrQuerySet
+from parasolr.query import SolrQuerySet, EmptySolrQuerySet
 
 
 class TestSolrQuerySet:
@@ -736,3 +736,23 @@ class TestSolrQuerySet:
 
         with pytest.raises(AssertionError):
             assert sqs[:-1]
+
+
+class TestEmptySolrQuerySet:
+
+    def test_init(self):
+        # Can't be instantiated
+        with pytest.raises(TypeError):
+            EmptySolrQuerySet()
+
+    def test_is_instance(self):
+        mocksolr = Mock(spec=SolrClient)
+        sqs = SolrQuerySet(mocksolr)
+        results = Mock()
+        results.docs = ParasolrDict() # empty response
+        sqs.solr.query = Mock(return_value=results)
+        # Queries that have zero results are an EmptySolrQuerySet
+        assert isinstance(sqs, EmptySolrQuerySet)
+        # Calling none() on a queryset returns an EmptySolrQuerySet
+        assert isinstance(sqs.none(), EmptySolrQuerySet)
+        

--- a/parasolr/query/tests/test_queryset.py
+++ b/parasolr/query/tests/test_queryset.py
@@ -98,7 +98,6 @@ class TestSolrQuerySet:
         # result cache not set on original
         assert not sqs._result_cache
 
-
     def test_get_results(self):
         mocksolr = Mock(spec=SolrClient)
         sqs = SolrQuerySet(mocksolr)
@@ -170,7 +169,8 @@ class TestSolrQuerySet:
 
         # now test no cached result
         mocksolr.query.return_value = Mock()
-        mocksolr.query.return_value.facet_counts = {'facet_fields': OrderedDict(b=2)}
+        mocksolr.query.return_value.facet_counts = {
+            'facet_fields': OrderedDict(b=2)}
         sqs._result_cache = None
         # clear the previous mocks
         mockQR.reset_mock()
@@ -562,7 +562,6 @@ class TestSolrQuerySet:
         assert custom_clone.stats_opts == custom_sqs.stats_opts
         assert not custom_clone.stats_opts is custom_sqs.stats_opts
 
-
         # subclass clone should return subclass
 
         class CustomSolrQuerySet(SolrQuerySet):
@@ -740,19 +739,22 @@ class TestSolrQuerySet:
 
 class TestEmptySolrQuerySet:
 
-    def test_init(self):
+    def test_no_init(self):
         # Can't be instantiated
         with pytest.raises(TypeError):
             EmptySolrQuerySet()
 
-    def test_is_instance(self):
+    def test_empty_qs_is_instance(self):
         mocksolr = Mock(spec=SolrClient)
         sqs = SolrQuerySet(mocksolr)
-        results = Mock()
-        results.docs = ParasolrDict() # empty response
-        sqs.solr.query = Mock(return_value=results)
         # Queries that have zero results are an EmptySolrQuerySet
+        mocksolr.query.return_value.docs = ParasolrDict()
         assert isinstance(sqs, EmptySolrQuerySet)
-        # Calling none() on a queryset returns an EmptySolrQuerySet
-        assert isinstance(sqs.none(), EmptySolrQuerySet)
-        
+
+    def test_non_empty_qs_is_not_instance(self):
+        mocksolr = Mock(spec=SolrClient)
+        sqs = SolrQuerySet(mocksolr)
+        # Populated querysets are not an EmptySolrQuerySet
+        response = ParasolrDict({'docs': [{}, {}]})
+        mocksolr.query.return_value = response
+        assert not isinstance(sqs, EmptySolrQuerySet)

--- a/parasolr/solr/client.py
+++ b/parasolr/solr/client.py
@@ -15,7 +15,7 @@ from parasolr.solr.admin import CoreAdmin
 logger = logging.getLogger(__name__)
 
 
-## NOTE: As a rule, Solr parameters that are camelcased are retained that way
+# NOTE: As a rule, Solr parameters that are camelcased are retained that way
 # despite not being hugely Pythonic, for consistency with Solr's responses
 # and API documentation.
 
@@ -34,12 +34,17 @@ class ParasolrDict(AttrDict):
                 copy[k] = v
         return copy
 
+    def __repr__(self):
+        return 'ParasolrDict(%s)' % super(AttrDict, self).__repr__()
+
+
 class QueryResponse:
     """Thin wrapper to give access to Solr select responses.
 
     Args:
         response: A Solr query response
     """
+
     def __init__(self, response: Dict) -> None:
         # cast to ParasolrDict for any dict-like object
         response = ParasolrDict(response)
@@ -74,8 +79,8 @@ class QueryResponse:
                     OrderedDict(zip(v[::2], v[1::2]))
         if 'facet_ranges' in facet_counts:
             for k, v in facet_counts.facet_ranges.items():
-               facet_counts['facet_ranges'][k]['counts'] = \
-                   OrderedDict(zip(v['counts'][::2], v['counts'][1::2]))
+                facet_counts['facet_ranges'][k]['counts'] = \
+                    OrderedDict(zip(v['counts'][::2], v['counts'][1::2]))
         return facet_counts
 
 
@@ -102,7 +107,6 @@ class SolrClient(ClientBase):
     #: commitWithin time in ms
     commitWithin = 1000
 
-
     def __init__(self, solr_url: str, collection: str,
                  commitWithin: Optional[int] = None,
                  session: Optional[requests.Session] = None) -> None:
@@ -114,8 +118,8 @@ class SolrClient(ClientBase):
         if commitWithin:
             self.commitWithin = commitWithin
         self.session.headers = {
-            'User-Agent': 'parasolr/%s (python-requests/%s)' % \
-                (parasol_version, requests.__version__)
+            'User-Agent': 'parasolr/%s (python-requests/%s)' %
+            (parasol_version, requests.__version__)
         }
 
         # attach remainder of API using a common session

--- a/parasolr/solr/client.py
+++ b/parasolr/solr/client.py
@@ -35,6 +35,7 @@ class ParasolrDict(AttrDict):
         return copy
 
     def __repr__(self):
+        """Print a dict-like :meth:`repr`, without including 'AttrDict'."""
         return 'ParasolrDict(%s)' % super(AttrDict, self).__repr__()
 
 

--- a/parasolr/solr/tests/test_client.py
+++ b/parasolr/solr/tests/test_client.py
@@ -14,13 +14,14 @@ from parasolr.solr.update import Update
 # up in conftest.py
 # Otherwise, they will be retained between test iterations and break results.
 
+
 class TestParasolrDict:
 
     def test_as_dict(self):
         para_dict = ParasolrDict({
             'a': 1,
             'b': ParasolrDict({
-                'c': [1, 2 ,3],
+                'c': [1, 2, 3],
                 'd': ParasolrDict({'z': 1})
             })
         })
@@ -38,6 +39,10 @@ class TestParasolrDict:
         # other structures should be untouched
         assert isinstance(as_dict['b']['c'], list)
 
+    def test_repr(self):
+        data = {'a': 1, 'b': 2}
+        para_dict = ParasolrDict(data)
+        assert repr(para_dict) == 'ParasolrDict(%s)' % repr(data)
 
 
 class TestQueryResponse:
@@ -58,14 +63,14 @@ class TestQueryResponse:
                 ],
             },
             'facet_counts': {
-                    'facet_fields': {
-                        'A': ['5', 1, '2', 1, '3', 1]
-                    },
-                    'facet_ranges': {
-                        'A': {
-                            'counts': ['1', 1, '2', 2, '7', 1]
-                        }
+                'facet_fields': {
+                    'A': ['5', 1, '2', 1, '3', 1]
+                },
+                'facet_ranges': {
+                    'A': {
+                        'counts': ['1', 1, '2', 2, '7', 1]
                     }
+                }
             },
             'stats': {
                 'stats_fields': {
@@ -114,7 +119,7 @@ class TestSolrClient:
         # test that session headers include the version name
         assert client.session.headers['User-Agent'] == \
             'parasolr/%s (python-requests/%s)' % (parasolr_ver,
-                                                 requests.__version__)
+                                                  requests.__version__)
 
     def test_query(self, test_client):
         # query of empty core produces the expected results

--- a/parasolr/solr/tests/test_client.py
+++ b/parasolr/solr/tests/test_client.py
@@ -40,7 +40,7 @@ class TestParasolrDict:
         assert isinstance(as_dict['b']['c'], list)
 
     def test_repr(self):
-        data = {'a': 1, 'b': 2}
+        data = {'a': 1,}
         para_dict = ParasolrDict(data)
         assert repr(para_dict) == 'ParasolrDict(%s)' % repr(data)
 


### PR DESCRIPTION
this adds a class that allows convenience comparisons using `isinstance()`, in the style of Django's `EmptyQuerySet`:
```python
assert isinstance(sqs, EmptySolrQuerySet) # sqs is empty
```

the tests feel a little weird since the empty check itself uses `__bool__`, which in turn evaluates the queryset and resets the result cache via `get_results()`, so I had to mock `solr.query()` rather than just setting the cache's contents directly. there's probably a better way to do it.