### PR TITLE
Feature/ppa support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ CHANGELOG
 * Schema field declarations now support the `stored` option
 * Schema field type declarations now pass through arbitrary options
 * New method `total_to_index` on `parasolr.indexing.Indexable` to better
-  support indexing content that is returneds as a generator
+  support indexing content that is returned as a generator
 * Access to expanded results now available on QueryResponse and SolrQuerySet
 * SolrQuerySet no longer wraps return results from `get_stats` and `get_facets` with QueryResponse
 * New last-modified view mixin for use with Django views `parasolr.django.views.SolrLastModifiedMixin`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,20 @@
 CHANGELOG
 =========
 
+0.6
+---
+
+* Solr client now escalates 404 errors instead of logging with no exception
+* Schema field declarations now support the `stored` option
+* Schema field type declarations now pass through arbitrary options
+* New method `total_to_index` on `parasolr.indexing.Indexable` to better
+  support indexing content that is returneds as a generator
+* Access to expanded results now available on QueryResponse and SolrQuerySet
+* SolrQuerySet no longer wraps return results from `get_stats` and `get_facets` with QueryResponse
+* New last-modified view mixin for use with Django views `parasolr.django.views.SolrLastModifiedMixin`
+* New pytest fixture `mock_solr_queryset` to generate a Mock SolrQuerySet that simulates the SolrQuerySet fluent interface
+
+
 0.5.4
 -----
 

--- a/parasolr/django/signals.py
+++ b/parasolr/django/signals.py
@@ -122,8 +122,8 @@ class IndexableSignalHandler:
         for model, options in ModelIndexable.related:
             for signal_name, handler in options.items():
                 model_signal = getattr(models.signals, signal_name)
-                logger.debug('Registering %s signal handler for %s',
-                             signal_name, model)
+                logger.debug('Registering %s signal handler %s for %s',
+                             handler, signal_name, model)
                 model_signal.connect(handler, sender=model)
 
     @staticmethod

--- a/parasolr/django/views.py
+++ b/parasolr/django/views.py
@@ -16,7 +16,7 @@ class SolrLastModifiedMixin(View):
     """View mixin to add last modified headers based on Solr.
     By default, searches entire solr collection and returns the most
     recent last modified value (assumes **last_modified** field).
-    To filter for items specific to  your view, either
+    To filter for items specific to your view, either
     set :attr:`solr_lastmodified_filters` or
     implement :meth:`get_solr_lastmodified_filters`.
     """
@@ -35,6 +35,7 @@ class SolrLastModifiedMixin(View):
         filter_qs = self.get_solr_lastmodified_filters()
         sqs = SolrQuerySet().filter(**filter_qs) \
             .order_by('-last_modified').only('last_modified')
+
         try:
             # Solr stores date in isoformat; convert to datetime
             return solr_timestamp_to_datetime(sqs[0]['last_modified'])

--- a/parasolr/django/views.py
+++ b/parasolr/django/views.py
@@ -1,0 +1,63 @@
+import calendar
+
+from django.utils.cache import get_conditional_response
+from django.views.generic.base import View
+
+from parasolr.django import SolrQuerySet
+from parasolr.utils import solr_timestamp_to_datetime
+
+
+class SolrLastModifiedMixin(View):
+    """View mixin to add last modified headers based on Solr.
+    By default, searches entire solr collection and returns the most
+    recent last modified value (assumes **last_modified** field).
+    To filter for items specific to  your view, either
+    set :attr:`solr_lastmodified_filters` or
+    implement :meth:`get_solr_lastmodified_filters`.
+    """
+
+    #: solr query filter for getting last modified date
+    solr_lastmodified_filters = {}   # by default, find all
+
+    def get_solr_lastmodified_filters(self):
+        '''Get filters for last modified Solr query. By default returns
+        :attr:`solr_lastmodified_filters`.'''
+        return self.solr_lastmodified_filters
+
+    def last_modified(self):
+        '''Return last modified :class:`datetime.datetime` from the
+        specified Solr query'''
+        filter_qs = self.get_solr_lastmodified_filters()
+        sqs = SolrQuerySet().filter(**filter_qs) \
+            .order_by('-last_modified').only('last_modified')
+        try:
+            # Solr stores date in isoformat; convert to datetime
+            return solr_timestamp_to_datetime(sqs[0]['last_modified'])
+            # skip extra call to Solr to check count and just grab the first
+            # item if it exists
+        except (IndexError, KeyError):
+            # if a syntax or other solr error happens, no date to return
+            pass
+
+    def dispatch(self, request, *args, **kwargs):
+        '''Wrap the dispatch method to add a last modified header if
+        one is available, then return a conditional response.'''
+
+        # NOTE: this doesn't actually skip view processing,
+        # but without it we could return a not modified for a non-200 response
+        response = super(SolrLastModifiedMixin, self) \
+            .dispatch(request, *args, **kwargs)
+
+        last_modified = self.last_modified()
+        if last_modified:
+            # remove microseconds so that comparison will pass,
+            # since microseconds are not included in the last-modified header
+            last_modified = last_modified.replace(microsecond=0)
+            response['Last-Modified'] = last_modified \
+                .strftime('%a, %d %b %Y %H:%M:%S GMT')
+            # convert the same way django does so that they will
+            # compare correctly
+            last_modified = calendar.timegm(last_modified.utctimetuple())
+
+        return get_conditional_response(request, last_modified=last_modified,
+                                        response=response)

--- a/parasolr/indexing.py
+++ b/parasolr/indexing.py
@@ -41,9 +41,9 @@ class Indexable:
     `index_id` and `index` methods.
 
     When implementing an Indexable subclass where items_to_index
-    returns something like a generator, whicht does not expose either a
+    returns something like a generator, which does not expose either a
     `count` method or can be counted with `len`, for use with
-    the Django index manage comment you should
+    the Django index manage command you should
     implement `total_to_index` and return the number of items
     to be indexed.
     """

--- a/parasolr/indexing.py
+++ b/parasolr/indexing.py
@@ -101,6 +101,17 @@ class Indexable:
         except AttributeError:
             raise NotImplementedError
 
+    @classmethod
+    def total_to_index(cls):
+        """Get the total number of items to be indexed for a single class of
+        Indexable content. Subclasses should override this method
+        if necessary. By default, returns a Django queryset count for a model.
+        Raises NotImplementedError if that fails."""
+        try:
+            return cls.objects.count()
+        except AttributeError:
+            raise NotImplementedError
+
     def index_id(self):
         """Solr identifier. By default, combines :meth:`index item_type`
         and :attr:`id` with :attr:ID_SEPARATOR`."""

--- a/parasolr/indexing.py
+++ b/parasolr/indexing.py
@@ -117,8 +117,7 @@ class Indexable:
         }
 
     def index(self):
-        """Index the current object in Solr.  Allows passing in
-        parameter, e.g. to set a `commitWithin` value.
+        """Index the current object in Solr.
         """
         self.solr.update.index([self.index_data()])
 

--- a/parasolr/indexing.py
+++ b/parasolr/indexing.py
@@ -39,6 +39,13 @@ def all_subclasses(cls):
 class Indexable:
     """Mixin for objects that are indexed in Solr.  Subclasses must implement
     `index_id` and `index` methods.
+
+    When implementing an Indexable subclass where items_to_index
+    returns something like a generator, whicht does not expose either a
+    `count` method or can be counted with `len`, for use with
+    the Django index manage comment you should
+    implement `total_to_index` and return the number of items
+    to be indexed.
     """
 
     # NOTE: current implementation is Django-specific, intended for
@@ -78,6 +85,8 @@ class Indexable:
         across all Indexable items in an application. By default, uses
         Django model verbose name. Used in default index id and
         in index manage command. """
+        # TODO: move this implementation into django subclass?
+        # default could just return an attribute on the class
         return cls._meta.verbose_name
 
     @classmethod

--- a/parasolr/management/commands/index.py
+++ b/parasolr/management/commands/index.py
@@ -116,13 +116,18 @@ class Command(BaseCommand):
             # calculate total to index across all indexables for current mode
             for name, model in self.indexables.items():
                 if self.options['index'] in [name, 'all']:
-                    # possibly inefficient to generate the list just
-                    # for a count; should be ok for django queryset implementation,
-                    # hopefully not too bad for other cases
+                    # Note this is likely inefficient to generate the list
+                    # for a count; should be ok for django queryset;
+                    # other cases should implement total_to_index
                     items = model.items_to_index()
                     if items:
                         try:
-                            # try count, since it's more effecient for
+                            # first check for method to provide
+                            # counts for non-models
+                            total_to_index += model.total_to_index()
+                        except AttributeError:
+                            # if method is not present,
+                            # try count, since it's more efficient for
                             # django querysets
                             total_to_index += items.count()
                         except TypeError:
@@ -147,7 +152,8 @@ class Command(BaseCommand):
             for name, model in self.indexables.items():
                 if self.options['index'] in [name, 'all']:
                     # index in chunks and update progress bar
-                    count += self.index(model.items_to_index(), progbar=progbar)
+                    count += self.index(model.items_to_index(),
+                                        progbar=progbar)
 
         if progbar:
             progbar.finish()

--- a/parasolr/management/commands/index.py
+++ b/parasolr/management/commands/index.py
@@ -116,23 +116,15 @@ class Command(BaseCommand):
             # calculate total to index across all indexables for current mode
             for name, model in self.indexables.items():
                 if self.options['index'] in [name, 'all']:
-                    # Note this is likely inefficient to generate the list
-                    # for a count; should be ok for django queryset;
-                    # other cases should implement total_to_index
                     items = model.items_to_index()
                     if items:
                         try:
                             # first check for method to provide
                             # counts for non-models
                             total_to_index += model.total_to_index()
-                        except AttributeError:
-                            # if method is not present,
-                            # try count, since it's more efficient for
-                            # django querysets
-                            total_to_index += items.count()
-                        except TypeError:
-                            # if count errors because we have a list,
-                            # use len
+                        except (AttributeError, NotImplementedError):
+                            # if count errors because we have a non-model
+                            # indexable or a  list, fall back to len
                             total_to_index += len(items)
 
         # initialize progressbar if requested and indexing more than 5 items

--- a/parasolr/pytest_plugin.py
+++ b/parasolr/pytest_plugin.py
@@ -126,6 +126,18 @@ if django:
             sleep(0.1)
 
 
+def get_mock_solr_queryset(spec=SolrQuerySet):
+    mock_qs = MagicMock(spec=spec)
+
+    # simulate fluent interface
+    for meth in ['filter', 'facet', 'stats', 'facet_field', 'facet_range',
+                 'search', 'order_by', 'query', 'only', 'also',
+                 'highlight', 'raw_query_parameters', 'all', 'none']:
+        getattr(mock_qs, meth).return_value = mock_qs
+
+    return Mock(return_value=mock_qs)
+
+
 @pytest.fixture
 def mock_solr_queryset(request):
     '''Fixture to provide a :class:`unitest.mock.Mock` for
@@ -157,17 +169,6 @@ def mock_solr_queryset(request):
         mock_qs = self.mock_solr_queryset(MySolrQuerySet)
 
     '''
-
-    def get_mock_solr_queryset(spec=SolrQuerySet):
-        mock_qs = MagicMock(spec=spec)
-
-        # simulate fluent interface
-        for meth in ['filter', 'facet', 'stats', 'facet_field', 'facet_range',
-                     'search', 'order_by', 'query', 'only', 'also',
-                     'highlight', 'raw_query_parameters', 'all', 'none']:
-            getattr(mock_qs, meth).return_value = mock_qs
-
-        return Mock(return_value=mock_qs)
 
     # if scope is class or function and there is a class available,
     # convert the mock generator to a static method and set it on the class

--- a/parasolr/pytest_plugin.py
+++ b/parasolr/pytest_plugin.py
@@ -118,7 +118,7 @@ if django:
 
     @pytest.fixture
     def empty_solr():
-        # pytest solr fixture; updates solr schema
+        '''pytest fixture to clear out all content from configured Solr'''
         parasolr_django.SolrClient().update.delete_by_query('*:*')
         while(parasolr_django.SolrQuerySet().count() != 0):
             # sleep until we get records back; 0.1 seems to be enough

--- a/parasolr/pytest_plugin.py
+++ b/parasolr/pytest_plugin.py
@@ -126,37 +126,47 @@ def mock_solr_queryset(request):
     '''Fixture to provide a :class:`unitest.mock.Mock` for
     :class:`~parasolr.query.queryset.SolrQuerySet` that simplifies
     testing against a mocked version of the fluent interface. It returns
-    a mock callable for use with patching the class; when the mock is
-    called it will return the mock with the fluent interface.
+    a method to generate a Mock queryset class; the method has an
+    optional parameter for a queryset subclass to use for the `spec`
+    argument to Mock.
 
-    If called  from a class or function where the request provides access
-    to a class, the mock will be set as `mock_solr_queryset` on the class.
+    If called from a class or function where the request provides access
+    to a class, the mock generator method `mock_solr_queryset` will be
+    added to the class as a static method.
 
-    Example use::
+    Example uses:
 
+        @pytest.mark.usefixtures("mock_solr_queryset")
         class MyTestCaseTestCase):
 
-            @pytest.mark.usefixtures("mock_solr_queryset")
             def test_my_solr_method(self):
 
-            with patch('parasolr.queryset.SolrQuerySet',
-                   new=self.mock_solr_queryset) as mock_queryset_cls:
+                with patch('parasolr.queryset.SolrQuerySet',
+                       new=self.mock_solr_queryset()) as mock_queryset_cls:
 
-                mock_qs = mock_queryset_cls.return_value
-                mock_qs.search.assert_any_call(text='my test search')
+                    mock_qs = mock_queryset_cls.return_value
+                    mock_qs.search.assert_any_call(text='my test search')
+
+    To use with a custom queryset subclass::
+
+        mock_qs = self.mock_solr_queryset(MySolrQuerySet)
 
     '''
-    mock_qs = Mock(spec=SolrQuerySet)
-    # simulate fluent interface
-    for meth in ['filter', 'facet', 'stats', 'facet_field', 'facet_range',
-                 'search', 'order_by', 'query', 'only', 'also', 'highlight',
-                 'raw_query_parameters', 'all', 'none']:
-        getattr(mock_qs, meth).return_value = mock_qs
 
-    mock_qs_class = Mock(return_value=mock_qs)
+    @staticmethod
+    def get_mock_solr_queryset(spec=SolrQuerySet):
+        mock_qs = Mock(spec=spec)
+
+        # simulate fluent interface
+        for meth in ['filter', 'facet', 'stats', 'facet_field', 'facet_range',
+                     'search', 'order_by', 'query', 'only', 'also',
+                     'highlight', 'raw_query_parameters', 'all', 'none']:
+            getattr(mock_qs, meth).return_value = mock_qs
+
+        return Mock(return_value=mock_qs)
 
     # if scope is class or function and there is a class available,
-    # set the mock on the class
+    # set the mock generator on the class
     if request.scope in ['class', 'function'] and hasattr(request, 'cls'):
-        request.cls.mock_solr_queryset = mock_qs_class
-    return mock_qs_class
+        request.cls.mock_solr_queryset = get_mock_solr_queryset
+    return get_mock_solr_queryset

--- a/parasolr/pytest_plugin.py
+++ b/parasolr/pytest_plugin.py
@@ -1,5 +1,6 @@
 import logging
-from unittest.mock import Mock
+from time import sleep
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -119,6 +120,10 @@ if django:
     def empty_solr():
         # pytest solr fixture; updates solr schema
         parasolr_django.SolrClient().update.delete_by_query('*:*')
+        while(parasolr_django.SolrQuerySet().count() != 0):
+            # sleep until we get records back; 0.1 seems to be enough
+            # for local dev with local Solr
+            sleep(0.1)
 
 
 @pytest.fixture
@@ -155,7 +160,7 @@ def mock_solr_queryset(request):
 
     @staticmethod
     def get_mock_solr_queryset(spec=SolrQuerySet):
-        mock_qs = Mock(spec=spec)
+        mock_qs = MagicMock(spec=spec)
 
         # simulate fluent interface
         for meth in ['filter', 'facet', 'stats', 'facet_field', 'facet_range',

--- a/parasolr/pytest_plugin.py
+++ b/parasolr/pytest_plugin.py
@@ -154,7 +154,7 @@ def mock_solr_queryset(request):
     Example uses:
 
         @pytest.mark.usefixtures("mock_solr_queryset")
-        class MyTestCaseTestCase):
+        class MyTestCase(TestCase):
 
             def test_my_solr_method(self):
 

--- a/parasolr/pytest_plugin.py
+++ b/parasolr/pytest_plugin.py
@@ -36,7 +36,7 @@ if django:
 
         # if no solr connection is configured, bail out
         if not getattr(settings, 'SOLR_CONNECTIONS', None):
-            logger.warn('No Solr configuration found')
+            logger.warning('No Solr configuration found')
             return
 
         # copy default config for basic connection options (e.g. url)
@@ -158,7 +158,6 @@ def mock_solr_queryset(request):
 
     '''
 
-    @staticmethod
     def get_mock_solr_queryset(spec=SolrQuerySet):
         mock_qs = MagicMock(spec=spec)
 
@@ -171,7 +170,8 @@ def mock_solr_queryset(request):
         return Mock(return_value=mock_qs)
 
     # if scope is class or function and there is a class available,
-    # set the mock generator on the class
-    if request.scope in ['class', 'function'] and hasattr(request, 'cls'):
-        request.cls.mock_solr_queryset = get_mock_solr_queryset
+    # convert the mock generator to a static method and set it on the class
+    if request.scope in ['class', 'function'] and \
+       getattr(request, 'cls', None):
+        request.cls.mock_solr_queryset = staticmethod(get_mock_solr_queryset)
     return get_mock_solr_queryset

--- a/parasolr/query/queryset.py
+++ b/parasolr/query/queryset.py
@@ -100,7 +100,7 @@ class SolrQuerySet:
     def _set_faceting_opts(self, query_opts: Dict) -> None:
         """Configure faceting attributes directly on query_opts. Modifies
         dictionary directly."""
-        if self.facet_field_list or self.range_facet_fields:
+        if self.facet_field_list or self.range_facet_fields or self.facet_opts:
             query_opts.update({
                 'facet': True,
                 'facet.field': self.facet_field_list,

--- a/parasolr/query/queryset.py
+++ b/parasolr/query/queryset.py
@@ -212,11 +212,7 @@ class SolrQuerySet:
         if self._result_cache:
             return self._result_cache.stats
 
-        query_opts = self.query_opts()
-        query_opts['rows'] = 0
-        query_opts['hl'] = False
-
-        response = self.solr.query(rows=0, hl=False)  # **query_opts)
+        response = self.solr.query(rows=0, hl=False)
         if response:
             return response.stats
 
@@ -537,8 +533,7 @@ class SolrQuerySet:
         qs_copy.search_qs = ['NOT *:*']
         return qs_copy
 
-    # def _clone(self) -> 'SolrQuerySet':
-    def _clone(self):
+    def _clone(self) -> 'SolrQuerySet':
         """
         Return a copy of the current QuerySet for modification via
         filters.

--- a/parasolr/query/queryset.py
+++ b/parasolr/query/queryset.py
@@ -194,6 +194,7 @@ class SolrQuerySet:
         if self._result_cache is not None:
             # wrap to process facets and return as dictionary
             # for Django template support
+            return self._result_cache.facet_counts
             qr = QueryResponse(self._result_cache)
             # NOTE: using dictionary syntax preserves OrderedDict
             return qr.facet_counts
@@ -223,6 +224,15 @@ class SolrQuerySet:
         response = self.solr.query(**query_opts)
         if response:
             return response.stats
+
+    def get_expanded(self) -> Dict[str, Dict]:
+        """Return a dictionary of expanded records included in the
+        Solr response.
+        """
+        if not self._result_cache:
+            self.get_results()
+
+        return self._result_cache.expanded
 
     @staticmethod
     def _lookup_to_filter(key: str, value: Any, tag: str = '') -> str:
@@ -532,7 +542,8 @@ class SolrQuerySet:
         qs_copy.search_qs = ['NOT *:*']
         return qs_copy
 
-    def _clone(self) -> 'SolrQuerySet':
+    # def _clone(self) -> 'SolrQuerySet':
+    def _clone(self):
         """
         Return a copy of the current QuerySet for modification via
         filters.

--- a/parasolr/query/queryset.py
+++ b/parasolr/query/queryset.py
@@ -168,7 +168,7 @@ class SolrQuerySet:
         """Total number of results for the current query"""
 
         # if result cache is already populated, use it
-        if self._result_cache is not None:
+        if self._result_cache:
             return self._result_cache.numFound
 
         # otherwise, query with current options but request zero rows
@@ -191,16 +191,11 @@ class SolrQuerySet:
         Solr response. Includes facet fields, facet ranges, etc. Facet
         field results are returned as an ordered dict of value and count.
         """
-        if self._result_cache is not None:
-            # wrap to process facets and return as dictionary
-            # for Django template support
+        if self._result_cache:
             return self._result_cache.facet_counts
-            qr = QueryResponse(self._result_cache)
-            # NOTE: using dictionary syntax preserves OrderedDict
-            return qr.facet_counts
+
         # since we just want a dictionary of facet fields, don't populate
         # the result cache, no rows needed
-
         query_opts = self.query_opts()
         query_opts['rows'] = 0
         query_opts['hl'] = False
@@ -214,14 +209,14 @@ class SolrQuerySet:
     def get_stats(self) -> Optional[Dict[str, ParasolrDict]]:
         """Return a dictionary of stats information in Solr format or None
         on error."""
-        if self._result_cache is not None:
-            qr = QueryResponse(self._result_cache)
-            return qr.stats
+        if self._result_cache:
+            return self._result_cache.stats
+
         query_opts = self.query_opts()
         query_opts['rows'] = 0
         query_opts['hl'] = False
 
-        response = self.solr.query(**query_opts)
+        response = self.solr.query(rows=0, hl=False)  # **query_opts)
         if response:
             return response.stats
 
@@ -601,7 +596,7 @@ class SolrQuerySet:
 
         # if the result cache is already populated,
         # return the requested index or slice
-        if self._result_cache is not None:
+        if self._result_cache:
             return self._result_cache.docs[k]
 
         qs_copy = self._clone()

--- a/parasolr/query/tests/test_queryset.py
+++ b/parasolr/query/tests/test_queryset.py
@@ -228,9 +228,15 @@ class TestSolrQuerySet:
             assert result == sqs._result_cache.expanded
             mock_get_results.assert_not_called()
 
-            # Not sure how to test without cache since
-            # currently using get_results to populate cache
-            # on the instance
+            # Not sure how to mock a class attribute so it is None
+            # and then populated as a side effect...
+            # This triggers the get results call but causes an exception
+            # trying to return an attribute of the result cache, which is
+            # still unset because we didn't call the real get_results
+            with pytest.raises(AttributeError):
+                sqs._result_cache = None
+                result = sqs.get_expanded()
+                mock_get_results.assert_any_call()
 
     def test_filter(self):
         mocksolr = Mock(spec=SolrClient)

--- a/parasolr/query/tests/test_queryset.py
+++ b/parasolr/query/tests/test_queryset.py
@@ -161,8 +161,6 @@ class TestSolrQuerySet:
         mocksolr = Mock(spec=SolrClient)
         # mock cached solr response
         sqs = SolrQuerySet(mocksolr)
-        # mock out return of MockQR constructor to ensure it calls
-        # facet_counts.facet_fields
         sqs._result_cache = Mock()
         sqs._result_cache.facet_counts = {'facet_fields': OrderedDict(a=1)}
 
@@ -219,6 +217,20 @@ class TestSolrQuerySet:
         assert kwargs['hl'] is False
         # returns the stats property of query call
         assert ret == mocksolr.query.return_value.stats
+
+    def test_get_expanded(self):
+        mocksolr = Mock(spec=SolrClient)
+        # mock cached solr response
+        with patch.object(SolrQuerySet, 'get_results') as mock_get_results:
+            sqs = SolrQuerySet(mocksolr)
+            sqs._result_cache = Mock()
+            result = sqs.get_expanded()
+            assert result == sqs._result_cache.expanded
+            mock_get_results.assert_not_called()
+
+            # Not sure how to test without cache since
+            # currently using get_results to populate cache
+            # on the instance
 
     def test_filter(self):
         mocksolr = Mock(spec=SolrClient)

--- a/parasolr/query/tests/test_queryset.py
+++ b/parasolr/query/tests/test_queryset.py
@@ -222,21 +222,24 @@ class TestSolrQuerySet:
         mocksolr = Mock(spec=SolrClient)
         # mock cached solr response
         with patch.object(SolrQuerySet, 'get_results') as mock_get_results:
+            # simulate cache populating
             sqs = SolrQuerySet(mocksolr)
             sqs._result_cache = Mock()
             result = sqs.get_expanded()
             assert result == sqs._result_cache.expanded
             mock_get_results.assert_not_called()
 
+            # simulate cache not populating
             # Not sure how to mock a class attribute so it is None
-            # and then populated as a side effect...
+            # and then populated as a side effect.
             # This triggers the get results call but causes an exception
             # trying to return an attribute of the result cache, which is
             # still unset because we didn't call the real get_results
             with pytest.raises(AttributeError):
                 sqs._result_cache = None
                 result = sqs.get_expanded()
-                mock_get_results.assert_any_call()
+
+            mock_get_results.assert_any_call()
 
     def test_filter(self):
         mocksolr = Mock(spec=SolrClient)

--- a/parasolr/schema.py
+++ b/parasolr/schema.py
@@ -100,15 +100,17 @@ class SolrField:
     """
 
     def __init__(self, fieldtype: str, required: bool=False,
-                 multivalued: bool=False, default: str=None):
+                 multivalued: bool=False, default: str=None,
+                 stored: bool=True):
         self.type = fieldtype
         self.required = required
         self.multivalued = multivalued
         self.default = default
+        self.stored = stored
 
     def __get__(self, obj, objtype):
         opts = {'type': self.type, 'required': self.required,
-                'multiValued': self.multivalued}
+                'multiValued': self.multivalued, 'stored': self.stored}
         if self.default:
             opts['default'] = self.default
         return opts

--- a/parasolr/schema.py
+++ b/parasolr/schema.py
@@ -166,20 +166,24 @@ class SolrFieldType:
     Args:
         field_class: The class of the SolrField
         analyzer: The name of the Solr analyzer to use on the field.
+        Additional field options can be passed as keyword arguments.
 
     Raises:
         AttributeError: If __set__ is called.
     """
-    def __init__(self, field_class: str, analyzer: str):
+    def __init__(self, field_class: str, analyzer: str, **kwargs: Any):
         self.field_class = field_class
         self.analyzer = analyzer
+        self.opts = kwargs
 
     def __get__(self, obj, objtype):
         # return format neded for declaring field type
-        return {
+        opts = self.opts.copy()
+        opts.update({
             'class': self.field_class,
             'analyzer': self.analyzer.as_solr_config()
-        }
+        })
+        return opts
 
     def __set__(self, obj, val):
         # enforce read-only descriptor

--- a/parasolr/solr/__init__.py
+++ b/parasolr/solr/__init__.py
@@ -1,2 +1,3 @@
 
+from parasolr.solr.base import SolrClientException
 from parasolr.solr.client import SolrClient

--- a/parasolr/solr/admin.py
+++ b/parasolr/solr/admin.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 from attrdict import AttrDict
 import requests
 
-from parasolr.solr.base import ClientBase
+from parasolr.solr.base import ClientBase, SolrConnectionNotFound
 
 
 class CoreAdmin(ClientBase):
@@ -81,7 +81,10 @@ class CoreAdmin(ClientBase):
         ping_url = '/'.join([self.solr_url.rstrip('/'), core, 'admin', 'ping'])
         # ping returns 404 if core does not exist, but that's ok here
         allowed_responses = [requests.codes.ok, requests.codes.not_found]
-        response = self.make_request('get', ping_url,
-                                     allowed_responses=allowed_responses)
-        # return True if response is valid and status is OK
-        return response and response.status == 'OK'
+        try:
+            response = self.make_request('get', ping_url,
+                                         allowed_responses=allowed_responses)
+            # return True if response is valid and status is OK
+            return response and response.status == 'OK'
+        except SolrConnectionNotFound:
+            return False

--- a/parasolr/solr/base.py
+++ b/parasolr/solr/base.py
@@ -13,17 +13,19 @@ logger = logging.getLogger(__name__)
 
 class SolrClientException(Exception):
     """Base class for all exceptions in this module"""
-    pass
 
 
 class CoreExists(SolrClientException):
     """Raised when a Solr core exists and it should not."""
-    pass
 
 
 class ImproperConfiguration(SolrClientException):
     """Raised when a required setting is not present or is an invalid value."""
-    pass
+
+
+class SolrConnectionNotFound(SolrClientException):
+    """Raised when a 404 is returned from Solr (e.g., attempting to query
+    a non-existent collection on a valid Solr server)"""
 
 
 class ClientBase:
@@ -38,7 +40,6 @@ class ClientBase:
             self.session = requests.Session()
         else:
             self.session = session
-
 
     def build_url(self, solr_url: str, collection: str, handler: str) -> str:
         """Return a url to a handler based on core and base url.
@@ -118,7 +119,7 @@ class ClientBase:
         # 404 error should be escalated, since it likely means a
         # misconfiguration (wrong core name or core not created)
         if response.status_code == requests.codes.not_found:
-            raise SolrClientException('404 Not Found: %s' % url)
+            raise SolrConnectionNotFound('404 Not Found: %s' % url)
 
         if response.status_code not in allowed_responses:
             # Add the content of the response on the off chance

--- a/parasolr/solr/base.py
+++ b/parasolr/solr/base.py
@@ -115,6 +115,11 @@ class ClientBase:
         if allowed_responses is None:
             allowed_responses = [requests.codes.ok]
 
+        # 404 error should be escalated, since it likely means a
+        # misconfiguration (wrong core name or core not created)
+        if response.status_code == requests.codes.not_found:
+            raise SolrClientException('404 Not Found: %s' % url)
+
         if response.status_code not in allowed_responses:
             # Add the content of the response on the off chance
             # it's helpful

--- a/parasolr/solr/client.py
+++ b/parasolr/solr/client.py
@@ -61,6 +61,7 @@ class QueryResponse:
             self.facet_counts = \
                 self._process_facet_counts(response.facet_counts)
         self.highlighting = response.get('highlighting', {})
+        self.expanded = response.get('expanded', {})
 
         # NOTE: To access facet_counts.facet_fields or facet_counts.facet_ranges
         # as OrderedDicts, you must use dict notation (or AttrDict *will*

--- a/parasolr/tests/test_indexing.py
+++ b/parasolr/tests/test_indexing.py
@@ -156,3 +156,19 @@ class TestIndexable:
         # raises not implemented if objects.all fails
         with pytest.raises(NotImplementedError):
             NonModelIndexable.items_to_index()
+
+    def test_total_to_index(self, mocksolr):
+        # assumes django model manager interface by default
+
+        # simple object with objects.all interface
+        assert SimpleIndexable.total_to_index() == 5
+
+        # model-ish object
+        assert MockModelIndexable.total_to_index() == 1
+
+        class NonModelIndexable(Indexable):
+            pass
+
+        # raises not implemented if objects.all fails
+        with pytest.raises(NotImplementedError):
+            NonModelIndexable.total_to_index()

--- a/parasolr/tests/test_pytest_plugin.py
+++ b/parasolr/tests/test_pytest_plugin.py
@@ -8,12 +8,12 @@ try:
     from django.conf import settings
     from django.test import override_settings
 
-    from parasolr.pytest_plugin import get_test_solr_config, \
-        get_mock_solr_queryset
+    from parasolr.pytest_plugin import get_test_solr_config
 
 except ImportError:
     pass
 
+from parasolr.pytest_plugin import get_mock_solr_queryset
 from parasolr.query import SolrQuerySet
 from parasolr.tests.utils import skipif_no_django
 

--- a/parasolr/tests/test_schema.py
+++ b/parasolr/tests/test_schema.py
@@ -17,20 +17,29 @@ def test_solr_fields():
         multival_str = schema.SolrStringField(multivalued=True)
         custom_field = schema.SolrField('text_en')
         last_modified = schema.SolrField('date', default='NOW')
+        unstored = schema.SolrField('text_en', stored=False)
 
     # get on the field returns solr config info
     assert TestySolrFields.mystring ==  \
-        {'type': 'string', 'required': False, 'multiValued': False}
+        {'type': 'string', 'required': False, 'multiValued': False,
+         'stored': True}
     assert TestySolrFields.required_str ==  \
-        {'type': 'string', 'required': True, 'multiValued': False}
+        {'type': 'string', 'required': True, 'multiValued': False,
+         'stored': True}
     assert TestySolrFields.multival_str ==  \
-        {'type': 'string', 'required': False, 'multiValued': True}
+        {'type': 'string', 'required': False, 'multiValued': True,
+         'stored': True}
     assert TestySolrFields.custom_field ==  \
-        {'type': 'text_en', 'required': False, 'multiValued': False}
+        {'type': 'text_en', 'required': False, 'multiValued': False,
+         'stored': True}
     # with default specified
     assert TestySolrFields.last_modified ==  \
         {'type': 'date', 'required': False, 'multiValued': False,
-         'default': 'NOW'}
+         'default': 'NOW', 'stored': True}
+    # with stored false
+    assert TestySolrFields.unstored ==  \
+        {'type': 'text_en', 'required': False, 'multiValued': False,
+         'stored': False}
 
     # explicitly read-only
     with pytest.raises(AttributeError):


### PR DESCRIPTION
Updates to parasolr to support PPA

---
functionality is in place, but still needs tests for new/changed code
- [x] test new pytest fixture `mock_solr_queryset`
- [x] test `SolrLastModifiedMixin` view ported from mep-django
- [x] queryset get_expanded
- [x] test indexing manage command `total_to_index` fallback