### PR TITLE
Correct path to testsettings.py in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ requires a minimal settings file for Django-required configurations.
 
 - Copy sample test settings and add a secret key::
 
-   cp ci/testsettings.py.sample testsettings.py
+   cp ci/testsettings.py testsettings.py
    python -c "import uuid; print('\nSECRET_KEY = \'%s\'' % uuid.uuid4())" >> testsettings.py
 
 - To run the test, either use the configured setup.py test command::


### PR DESCRIPTION
The README specified a path to a nonexistent file `ci/testsettings.py.sample`; `ci/testsettings.py` should be used instead.