### PR TITLE
Add support for highlighting multiple fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ CHANGELOG
 0.8
 ---
 * Pytest fixture ``mock_solr_queryset`` now takes optional argument for extra methods to include in fluent interface
+* ``SolrQuerySet`` now supports highlighting on multiple fields via ``highlight`` method, with per-field highlighting options.
+* ``AliasedSolrQuerySet`` now correctly aliases fieldnames in highlighting results.
 
 0.7
 ---

--- a/parasolr/query/aliased_queryset.py
+++ b/parasolr/query/aliased_queryset.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 from parasolr.query.queryset import SolrQuerySet
 
@@ -130,6 +130,15 @@ class AliasedSolrQuerySet(SolrQuerySet):
             }
         return stats
 
-    # NOTE: may want to do the same for highlighting also eventually,
-    # but no immediate need and it's structured differently so
-    # not as obvious how to handle
+    def get_highlighting(self) -> Dict[str, Dict[str, List]]:
+        highlighting = super().get_highlighting()
+        # highlighting results are keyed on document id
+        # for each document, there is a dictionary of highlights;
+        # key is field name, value is the list of snippets
+        if highlighting:
+            for doc_id, highlights in highlighting.items():
+                highlighting[doc_id] = {
+                    self.reverse_aliases.get(field, field): snippets
+                    for field, snippets in highlights.items()
+                }
+        return highlighting

--- a/parasolr/query/tests/test_queryset.py
+++ b/parasolr/query/tests/test_queryset.py
@@ -36,8 +36,8 @@ class TestSolrQuerySet:
         sqs.filter_qs = ['item_type_s:work']
         sqs.search_qs = ['title:reading', 'author:johnson']
         sqs.field_list = ['title', 'author', 'date:pubyear_i']
-        sqs.highlight_field = 'content'
-        sqs.highlight_opts = {'snippets': 3, 'method': 'unified'}
+        sqs.highlight_fields = ['content']
+        sqs.highlight_opts = {'f.content.hl.snippets': 3, 'f.content.hl.method': 'unified'}
         sqs.facet_field_list = ['item_type_s', 'member_type']
         sqs.facet_opts = {'sort': 'count'}
         sqs.stats_field_list = ['item_type_s', 'account_start_i']
@@ -54,9 +54,9 @@ class TestSolrQuerySet:
         # highlighting should be turned on
         assert query_opts['hl']
         assert query_opts['hl.fl'] == 'content'
-        # highlighting options added with hl.prefix
-        assert query_opts['hl.snippets'] == 3
-        assert query_opts['hl.method'] == 'unified'
+        # highlighting options added as-is
+        assert query_opts['f.content.hl.snippets'] == 3
+        assert query_opts['f.content.hl.method'] == 'unified'
         # make sure faceting opts are preserved
         assert query_opts['facet'] is True
         assert query_opts['facet.field'] == sqs.facet_field_list
@@ -468,18 +468,19 @@ class TestSolrQuerySet:
         sqs = SolrQuerySet(mocksolr)
         # field only, defaults
         highlight_qs = sqs.highlight('content')
-        assert highlight_qs.highlight_field == 'content'
+        assert highlight_qs.highlight_fields == ['content']
         assert highlight_qs.highlight_opts == {}
         # original unchanged
-        assert sqs.highlight_field is None
+        assert sqs.highlight_fields == []
 
         # field and opts
         highlight_qs = sqs.highlight('text', snippets=3, method='unified')
-        assert highlight_qs.highlight_field == 'text'
+        assert highlight_qs.highlight_fields == ['text']
+        print(highlight_qs.highlight_opts)
         assert highlight_qs.highlight_opts == \
-            {'snippets': 3, 'method': 'unified'}
+            {'f.text.hl.snippets': 3, 'f.text.hl.method': 'unified'}
         # original unchanged
-        assert sqs.highlight_field is None
+        assert sqs.highlight_fields == []
         assert sqs.highlight_opts == {}
 
     def test_raw_query_parameters(self):


### PR DESCRIPTION
- revises `highlight` logic in `SolrQuerySet` so it doesn't assume a single field; now handles multiple fields, and configures highlighting options on a per-field basis
- updates `AliasedSolrQuerySet` to add aliasing to fields in `get_highlighting` response